### PR TITLE
[feature] Add Tavily search/extract backend for web tools

### DIFF
--- a/docs/site/en/reference/configuration.md
+++ b/docs/site/en/reference/configuration.md
@@ -47,6 +47,8 @@ tools:
   web:
     search_backend: ddgs
     extract_backend: fetch
+    # Paid backends such as tavily / exa / firecrawl need api_key or api_key_env
+    # api_key_env: TAVILY_API_KEY
     max_extract_urls: 5
     max_content_bytes: 2000000
 

--- a/docs/site/zh/reference/configuration.md
+++ b/docs/site/zh/reference/configuration.md
@@ -47,6 +47,8 @@ tools:
   web:
     search_backend: ddgs
     extract_backend: fetch
+    # tavily / exa / firecrawl 等付费后端需要配置 api_key 或 api_key_env
+    # api_key_env: TAVILY_API_KEY
     max_extract_urls: 5
     max_content_bytes: 2000000
 

--- a/dojoagents/config/loader.py
+++ b/dojoagents/config/loader.py
@@ -114,6 +114,17 @@ def _provider_config(name: str, raw: dict[str, Any]) -> LLMProviderConfig:
     )
 
 
+def _resolve_optional_api_key(raw: dict[str, Any]) -> str | None:
+    api_key = raw.get("api_key")
+    api_key_env = raw.get("api_key_env")
+    if not api_key and api_key_env:
+        api_key = os.getenv(str(api_key_env))
+    if api_key is None:
+        return None
+    text = str(api_key).strip()
+    return text or None
+
+
 def resolve_provider_config(llm: LLMConfig, requested_name: str | None = None) -> tuple[str | None, LLMProviderConfig | None]:
     if not llm.providers:
         return None, None
@@ -174,6 +185,8 @@ def _to_config(raw: dict[str, Any]) -> AgentsConfig:
             user_agent=web_raw.get("user_agent"),
             search_base_url=web_raw.get("search_base_url"),
             extract_base_url=web_raw.get("extract_base_url"),
+            api_key=_resolve_optional_api_key(web_raw),
+            api_key_env=web_raw.get("api_key_env"),
             max_extract_urls=int(web_raw.get("max_extract_urls", 5)),
             max_content_bytes=int(web_raw.get("max_content_bytes", 2_000_000)),
             summary_threshold_chars=int(web_raw.get("summary_threshold_chars", 6000)),
@@ -324,6 +337,14 @@ class ConfigStore:
             provider["api_key_configured"] = configured
             if provider.get("api_key") or provider.get("api_key_env"):
                 provider["api_key"] = "***"
+        web = data.get("tools", {}).get("web")
+        if isinstance(web, dict):
+            web["api_key_configured"] = bool(web.get("api_key"))
+            if web.get("api_key") or web.get("api_key_env"):
+                web["api_key"] = "***"
+        dojosdk = data.get("dojosdk")
+        if isinstance(dojosdk, dict) and (dojosdk.get("api_key") or dojosdk.get("api_key_env")):
+            dojosdk["api_key"] = "***"
         return data
 
     def raw(self) -> dict[str, Any]:

--- a/dojoagents/config/models.py
+++ b/dojoagents/config/models.py
@@ -57,6 +57,8 @@ class WebToolsConfig:
     user_agent: str | None = None
     search_base_url: str | None = None
     extract_base_url: str | None = None
+    api_key: str | None = None
+    api_key_env: str | None = None
     max_extract_urls: int = 5
     max_content_bytes: int = 2_000_000
     summary_threshold_chars: int = 6000

--- a/dojoagents/dashboard/web/src/api/settings.ts
+++ b/dojoagents/dashboard/web/src/api/settings.ts
@@ -59,6 +59,8 @@ let mockConfig: SettingsConfig = {
       extract_backend: '',
       search_base_url: '',
       extract_base_url: '',
+      api_key: '',
+      api_key_env: '',
       max_extract_urls: 5,
       max_content_bytes: 2000000,
       summary_threshold_chars: 6000,

--- a/dojoagents/dashboard/web/src/components/settings/SettingsModal.tsx
+++ b/dojoagents/dashboard/web/src/components/settings/SettingsModal.tsx
@@ -324,6 +324,8 @@ function buildForm(cfg: SettingsConfig): SettingsFormState {
         extract_backend: asString(web.extract_backend),
         search_base_url: asString(web.search_base_url),
         extract_base_url: asString(web.extract_base_url),
+        api_key: web.api_key === '***' ? '' : asString(web.api_key),
+        api_key_env: asString(web.api_key_env),
         max_extract_urls: asNumber(web.max_extract_urls, 5),
         max_content_bytes: asNumber(web.max_content_bytes, 2_000_000),
         summary_threshold_chars: asNumber(web.summary_threshold_chars, 6000),
@@ -411,13 +413,26 @@ function buildPatch(form: SettingsFormState): SettingsConfig {
         allowed_roots: linesToArr(form.tools.sandbox.allowed_roots),
         allowed_commands: linesToArr(form.tools.sandbox.allowed_commands),
       },
-      web: {
-        ...form.tools.web,
-        search_backend: form.tools.web.search_backend || null,
-        extract_backend: form.tools.web.extract_backend || null,
-        search_base_url: form.tools.web.search_base_url || null,
-        extract_base_url: form.tools.web.extract_base_url || null,
-      },
+      web: (() => {
+        const {
+          api_key: webApiKey,
+          api_key_env: webApiKeyEnv,
+          search_backend: searchBackend,
+          extract_backend: extractBackend,
+          search_base_url: searchBaseUrl,
+          extract_base_url: extractBaseUrl,
+          ...webRest
+        } = form.tools.web;
+        return {
+          ...webRest,
+          search_backend: searchBackend || null,
+          extract_backend: extractBackend || null,
+          search_base_url: searchBaseUrl || null,
+          extract_base_url: extractBaseUrl || null,
+          api_key_env: webApiKeyEnv || null,
+          ...(webApiKey ? { api_key: webApiKey } : {}),
+        };
+      })(),
     },
     memory: { ...form.memory },
     skills: {
@@ -805,6 +820,12 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
                 </Field>
                 <Field label="Extract Base URL">
                   {textInput(form.tools.web.extract_base_url, (value) => updateField((draft) => { draft.tools.web.extract_base_url = value; }))}
+                </Field>
+                <Field label="Web API Key Env">
+                  {textInput(form.tools.web.api_key_env, (value) => updateField((draft) => { draft.tools.web.api_key_env = value; }), 'TAVILY_API_KEY')}
+                </Field>
+                <Field label="Web API Key">
+                  {textInput(form.tools.web.api_key, (value) => updateField((draft) => { draft.tools.web.api_key = value; }), '***', 'password')}
                 </Field>
                 <Field label="Max Extract URLs">
                   {numberInput(form.tools.web.max_extract_urls, (value) => updateField((draft) => { draft.tools.web.max_extract_urls = value; }), 1)}

--- a/dojoagents/dashboard/web/src/types/settings.ts
+++ b/dojoagents/dashboard/web/src/types/settings.ts
@@ -37,6 +37,8 @@ export interface SettingsFormState {
       extract_backend: string;
       search_base_url: string;
       extract_base_url: string;
+      api_key: string;
+      api_key_env: string;
       max_extract_urls: number;
       max_content_bytes: number;
       summary_threshold_chars: number;

--- a/dojoagents/tools/web_searcher.py
+++ b/dojoagents/tools/web_searcher.py
@@ -111,6 +111,22 @@ def _resolve_search_base_url(cfg: WebToolsConfig) -> str:
     return (cfg.search_base_url or "https://html.duckduckgo.com").rstrip("/")
 
 
+def _resolve_tavily_base_url(cfg: WebToolsConfig, *, kind: str) -> str:
+    if kind == "search":
+        return (cfg.search_base_url or "https://api.tavily.com").rstrip("/")
+    return (cfg.extract_base_url or cfg.search_base_url or "https://api.tavily.com").rstrip("/")
+
+
+def _require_web_api_key(cfg: WebToolsConfig) -> str:
+    key = (cfg.api_key or "").strip()
+    if key:
+        return key
+    raise RuntimeError(
+        "Web tools API key is not configured. Set tools.web.api_key or tools.web.api_key_env "
+        "(for example TAVILY_API_KEY) in ~/.dojo/agents.yaml"
+    )
+
+
 def _strip_html_to_text(raw: str) -> tuple[str, str]:
     title_match = re.search(r"<title[^>]*>(.*?)</title>", raw, flags=re.IGNORECASE | re.DOTALL)
     title = html.unescape(re.sub(r"\s+", " ", title_match.group(1)).strip()) if title_match else ""
@@ -218,6 +234,98 @@ async def _fetch_extract_adapter(
 
 
 register_extract_backend("fetch", _fetch_extract_adapter)
+
+
+async def _tavily_search_adapter(
+    query: str,
+    limit: int,
+    cfg: WebToolsConfig,
+) -> list[dict[str, Any]]:
+    api_key = _require_web_api_key(cfg)
+    base_url = _resolve_tavily_base_url(cfg, kind="search")
+    async with _make_async_client(
+        cfg,
+        headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+    ) as client:
+        response = await client.post(
+            f"{base_url}/search",
+            json={
+                "query": query,
+                "max_results": max(1, min(int(limit), 20)),
+                "include_answer": False,
+                "include_images": False,
+                "include_raw_content": False,
+            },
+        )
+        response.raise_for_status()
+        payload = response.json()
+    rows: list[dict[str, Any]] = []
+    for index, item in enumerate(list(payload.get("results") or []), start=1):
+        if index > limit:
+            break
+        rows.append(
+            {
+                "title": str(item.get("title") or ""),
+                "url": str(item.get("url") or ""),
+                "description": str(item.get("content") or item.get("snippet") or ""),
+                "position": index,
+            }
+        )
+    return rows
+
+
+register_search_backend("tavily", _tavily_search_adapter)
+
+
+async def _tavily_extract_adapter(
+    urls: list[str],
+    cfg: WebToolsConfig,
+) -> list[dict[str, Any]]:
+    api_key = _require_web_api_key(cfg)
+    base_url = _resolve_tavily_base_url(cfg, kind="extract")
+    async with _make_async_client(
+        cfg,
+        headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+    ) as client:
+        response = await client.post(
+            f"{base_url}/extract",
+            json={"urls": urls, "include_images": False},
+        )
+        response.raise_for_status()
+        payload = response.json()
+
+    by_url: dict[str, dict[str, Any]] = {}
+    for item in list(payload.get("results") or []):
+        url = str(item.get("url") or "")
+        if not url:
+            continue
+        by_url[url] = {
+            "url": url,
+            "title": str(item.get("title") or ""),
+            "content": str(item.get("raw_content") or item.get("content") or ""),
+            "error": None,
+        }
+    for item in list(payload.get("failed_results") or []):
+        url = str(item.get("url") or "")
+        if not url:
+            continue
+        by_url[url] = {
+            "url": url,
+            "title": "",
+            "content": "",
+            "error": str(item.get("error") or "extract failed"),
+        }
+
+    results: list[dict[str, Any]] = []
+    for url in urls:
+        if url in by_url:
+            results.append(by_url[url])
+        else:
+            results.append({"url": url, "title": "", "content": "", "error": "no extract result"})
+    return results
+
+
+register_extract_backend("tavily", _tavily_extract_adapter)
 
 
 def get_web_searcher_specs(cfg: WebToolsConfig) -> list[ToolSpec]:

--- a/tests/test_config_multi_agent_plan.py
+++ b/tests/test_config_multi_agent_plan.py
@@ -167,6 +167,8 @@ class TestConfigLoader:
                         "user_agent": "CustomBot/1.0",
                         "search_base_url": "http://localhost:8080",
                         "extract_base_url": "http://localhost:8081",
+                        "api_key": "tvly-test-key",
+                        "api_key_env": "TAVILY_API_KEY",
                         "summary_threshold_chars": 1200,
                     }
                 }
@@ -177,4 +179,19 @@ class TestConfigLoader:
         assert cfg.tools.web.user_agent == "CustomBot/1.0"
         assert cfg.tools.web.search_base_url == "http://localhost:8080"
         assert cfg.tools.web.extract_base_url == "http://localhost:8081"
+        assert cfg.tools.web.api_key == "tvly-test-key"
+        assert cfg.tools.web.api_key_env == "TAVILY_API_KEY"
         assert cfg.tools.web.summary_threshold_chars == 1200
+
+    def test_resolves_web_api_key_from_env(self, monkeypatch):
+        monkeypatch.setenv("TAVILY_API_KEY", "tvly-from-env")
+        cfg = _to_config(
+            {
+                "tools": {
+                    "web": {
+                        "api_key_env": "TAVILY_API_KEY",
+                    }
+                }
+            }
+        )
+        assert cfg.tools.web.api_key == "tvly-from-env"

--- a/tests/test_web_searcher.py
+++ b/tests/test_web_searcher.py
@@ -202,6 +202,112 @@ async def test_web_search_ddgs_adapter_parses_results(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_web_search_tavily_adapter_parses_results(monkeypatch):
+    from dojoagents.tools import web_searcher
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert str(request.url) == "https://api.tavily.com/search"
+        assert request.headers.get("authorization") == "Bearer tvly-test"
+        body = request.read()
+        import json
+
+        payload = json.loads(body.decode("utf-8"))
+        assert payload["query"] == "dojo"
+        assert payload["max_results"] == 2
+        return httpx.Response(
+            200,
+            json={
+                "results": [
+                    {
+                        "title": "Tavily Dojo",
+                        "url": "https://example.com/tavily",
+                        "content": "Tavily snippet",
+                    }
+                ]
+            },
+        )
+
+    def fake_client_factory(cfg, **kwargs):
+        return _mock_async_client(web_searcher, cfg, handler, **kwargs)
+
+    monkeypatch.setattr(web_searcher, "_make_async_client", fake_client_factory)
+
+    executor = _make_executor(
+        {
+            "tools": {
+                "web": {
+                    "search_backend": "tavily",
+                    "api_key": "tvly-test",
+                }
+            }
+        }
+    )
+    result = await executor.execute_one(
+        ToolCall(id="call-1", name="web_search", arguments={"query": "dojo", "limit": 2})
+    )
+
+    assert result.ok is True
+    assert result.metadata["backend"] == "tavily"
+    assert result.data["web"][0]["title"] == "Tavily Dojo"
+    assert result.data["web"][0]["description"] == "Tavily snippet"
+
+
+@pytest.mark.asyncio
+async def test_web_search_tavily_without_api_key_returns_error():
+    executor = _make_executor({"tools": {"web": {"search_backend": "tavily"}}})
+    result = await executor.execute_one(ToolCall(id="call-1", name="web_search", arguments={"query": "dojo"}))
+
+    assert result.ok is False
+    assert "api key" in result.error.lower()
+
+
+@pytest.mark.asyncio
+async def test_web_extract_tavily_adapter_parses_results(monkeypatch):
+    from dojoagents.tools import web_searcher
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert str(request.url) == "https://api.tavily.com/extract"
+        assert request.headers.get("authorization") == "Bearer tvly-test"
+        return httpx.Response(
+            200,
+            json={
+                "results": [
+                    {
+                        "url": "https://example.com/page",
+                        "title": "Extracted",
+                        "raw_content": "Full page content",
+                    }
+                ],
+                "failed_results": [],
+            },
+        )
+
+    def fake_client_factory(cfg, **kwargs):
+        return _mock_async_client(web_searcher, cfg, handler, **kwargs)
+
+    monkeypatch.setattr(web_searcher, "_make_async_client", fake_client_factory)
+
+    executor = _make_executor(
+        {
+            "tools": {
+                "web": {
+                    "extract_backend": "tavily",
+                    "api_key": "tvly-test",
+                }
+            }
+        }
+    )
+    result = await executor.execute_one(
+        ToolCall(id="call-1", name="web_extract", arguments={"url": "https://example.com/page"})
+    )
+
+    assert result.ok is True
+    assert result.metadata["backend"] == "tavily"
+    assert result.data["results"][0]["title"] == "Extracted"
+    assert result.data["results"][0]["content"] == "Full page content"
+
+
+@pytest.mark.asyncio
 async def test_web_extract_fetch_adapter_parses_results(monkeypatch):
     from dojoagents.tools import web_searcher
 


### PR DESCRIPTION
## Summary

Add a new `tavily` backend for the built-in web tools (`web_search` / `web_extract`), alongside the existing DuckDuckGo/fetch backends, with API key configuration support.

## Changes

### Backend (`dojoagents/tools/web_searcher.py`)
- Register `tavily` search backend: calls `POST {base_url}/search` with Bearer auth, maps `results[]` to the unified `{title, url, description, position}` rows (limit clamped to 1–20).
- Register `tavily` extract backend: calls `POST {base_url}/extract`, normalizes `results[]` / `failed_results[]` per input URL, preserving input order and filling `no extract result` for missing URLs.
- Add `_require_web_api_key` with a clear error message when the key is missing, and `_resolve_tavily_base_url` (defaults to `https://api.tavily.com`, extract falls back to search base URL).

### Config (`dojoagents/config/models.py`, `loader.py`)
- New `WebToolsConfig` fields: `api_key` and `api_key_env` (e.g. `TAVILY_API_KEY`); loader resolves the env var into `api_key`.

### Dashboard (`settings.ts`, `SettingsModal.tsx`, `types/settings.ts`)
- Expose `api_key` / `api_key_env` in the web tools settings UI and API types.

### Docs
- Document the new `tools.web.api_key` / `tools.web.api_key_env` options in EN/ZH configuration references.

## Usage

```yaml
# ~/.dojo/agents.yaml
tools:
  web:
    search_backend: tavily
    extract_backend: tavily
    api_key_env: TAVILY_API_KEY
