### PR TITLE
 fix: LOGGER.info() missing required argument

### DIFF
--- a/dojoagents/cli/model_setup.py
+++ b/dojoagents/cli/model_setup.py
@@ -47,7 +47,7 @@ def configure_model_connection(config_path: str | Path = "~/.dojo/agents.yaml") 
 
     current_default = llm_section.get("default", "openai")
     LOGGER.info(f"Current default provider: {current_default}")
-    LOGGER.info()
+    LOGGER.info("")
 
     # 1. Select Provider
     LOGGER.info("Select LLM Provider:")
@@ -139,7 +139,7 @@ def configure_model_connection(config_path: str | Path = "~/.dojo/agents.yaml") 
     raw.setdefault("agent", {})["model"] = selected_model
 
     store.save_raw(raw)
-    LOGGER.info()
+    LOGGER.info("")
     LOGGER.info(f"✓ Configuration successfully saved to {store.path}")
     LOGGER.info(f"  Active Provider: {provider_id}")
     LOGGER.info(f"  Active Model:    {selected_model}")


### PR DESCRIPTION
LOGGER.info() was called without arguments in
  configure_model_connection(), which raised a TypeError because
  the logging method requires a message string. Replaced with
  LOGGER.info("") to print blank lines for visual separation in
  the CLI output while satisfying the required argument.

  Found when running the DojoAgents model setup flow.