### PR TITLE
feat: improve configuration, memory management, and docs

### DIFF
--- a/docs/site/en/architecture/agent-internals.md
+++ b/docs/site/en/architecture/agent-internals.md
@@ -1,0 +1,322 @@
+# Agent Internals
+
+> This page answers a question the other docs never addressed head-on: **how is the DojoAgents agent capability actually built?**
+>
+> [Agent Loop](agent-loop.md) describes the conceptual turn. This page describes what really happens in code: which agent framework is embedded, how it is bridged, how the system prompt is assembled, who intercepts tool calls, how context is compacted, and where domain logic plugs in.
+>
+> Main entry point: `dojoagents/agent/loop.py`, especially `AgentLoop.run()`. Line numbers on this page are orientation aids for the documented snapshot; symbol names are the stable references.
+>
+> Evidence boundary: this page describes behavior observable in the current code. It does not claim to reconstruct undocumented framework-selection intent. Confirmed operational gaps are tracked in [Known Limitations](../development/known-limitations.md).
+
+---
+
+## 1. In one sentence
+
+**DojoAgents delegates the inner model-to-tool cycle to [Strands Agents](https://github.com/strands-agents/sdk-python), while `AgentLoop.run()` owns request orchestration, prompt assembly, bridges, hooks, recovery, domain validation and outward events.**
+
+```text
+        DojoAgents assets                         Strands Agents kernel
+  ┌───────────────────────────┐           ┌────────────────────────┐
+  │ LLMProvider (OpenAI-comp.)│──bridge─▶ │ strands.models.Model   │
+  │ ToolSpec + ToolExecutor   │──bridge─▶ │ strands.types.AgentTool│
+  │ SkillManager / Memory     │──compose▶ │ system_prompt          │
+  │ Guardrails / Harness      │──attach─▶ │ hooks (Before/After)   │
+  │ Plugins                   │──attach─▶ │ plugins                │
+  │ DojoAgentSessionManager   │──inject─▶ │ session_manager        │
+  └───────────────────────────┘           └────────────────────────┘
+                                                    │
+                                          agent.invoke_async(...)
+                                          multi-turn tool-use driven by kernel
+```
+
+---
+
+## 2. Frameworks in use
+
+| Dependency | Constraint | Role in the agent capability |
+| --- | --- | --- |
+| `strands-agents` | unpinned | **Agent event-loop kernel**: multi-turn tool-use orchestration, message state machine, hook/plugin system, `stop_reason` / `metrics` |
+| `strands-agents-tools` | unpinned | Official Strands tool collection (optional) |
+| `openai` | `>=1.20,<2` | SDK behind `OpenAICompatibleProvider`; also used for token accounting and context-window probing |
+| `mcp` | `>=1.26,<2` | MCP tool integration (`tools/mcp_tool.py`, `tools/mcp_oauth.py`) |
+| `fastapi` | `>=0.110,<0.112` | Exposes the agent through Dashboard / Gateway (SSE, OpenAI-compatible API) |
+| `apscheduler` | `>=3.10,<4` | Scheduled jobs that trigger agent runs |
+| `dojosdk` | `>=0.1.15` | Quant finance data, wrapped as tools (`tools/dojo_sdk_tool.py`) |
+
+Declared in `pyproject.toml` and `requirements.txt`.
+
+> **Observable integration trade-offs.** The code uses Strands for the model/tool cycle and hook protocol while retaining DojoAgents provider and tool contracts behind adapters. Mutable before/after tool events support cancellation and argument/result rewriting. These are properties of the implementation, not a documented comparison or selection rationale against other frameworks.
+
+---
+
+## 3. Six cross-cutting design ideas
+
+### 3.1 Anti-corruption layer
+
+The main Strands adaptation boundary is concentrated in `agent/loop.py`: `DojoStrandsModelBridge`, `DojoBridgedTool`, message conversion and invocation are implemented there. A small number of adjacent modules also use Strands contracts directly, including session management, empty-assistant recovery and the plugin bridge. Replacing the kernel would therefore require changing this boundary and those integration points, rather than only one bridge block.
+
+Two-way message translation supports this: outbound in `run()` stage 3 (`loop.py:647`), inbound via `strands_to_dojo_messages()` (`loop.py:324`), plus `compressor.flatten_messages_for_compress()` / `messages_to_strands()` around compaction.
+
+### 3.2 Generic loop + domain harness
+
+Domain constraints (a portfolio must exist before backtesting, an evaluation must be submitted, …) are **not** in the loop. They implement the `TaskHarness` protocol and are called back at six fixed points. See [§5.6](#56-harness-pluggable-domain-constraints).
+
+### 3.3 Context economics: progressive disclosure + active compaction
+
+- With `agent.lazy_skills: true` (the default), `SkillManager.prompt_block()` injects names/descriptions and bodies are fetched through `skill_view`. With lazy loading disabled, skill bodies are injected directly.
+- Tool results are pruned: `ContextCompressor.prune_old_tool_results()` keeps the tail, degrades older results to summaries (`_summarize_tool_result()`), and truncates argument JSON to 150 chars (`_truncate_tool_call_args_json()`).
+- Overflow self-heals: hitting the context limit triggers compaction and one retry ([§5.4](#54-context-and-token-governance)).
+
+### 3.4 Interception-based governance
+
+Governance is deliberately mixed. Guardrails, token compaction, memory integration, turn completion and plugin interception are assembled as hooks/plugins. `AgentLoop.run()` still performs explicit orchestration for harness resolution and repair, recovery attempts, event publication and final response handling. This split matters when extending or replacing the loop.
+
+### 3.5 Every capability is a ToolSpec
+
+Skill management, plugin management, terminal, code execution, session files, MCP, DojoSDK data and even **sub-agent delegation** all collapse into `ToolSpec` entries in `ToolRegistry`. `Runtime` merely decides what goes into the registry at assembly time.
+
+### 3.6 Event bus for decoupled side capabilities
+
+`dojoagents/utils/event_bus.py::EventBus` offers `publish(topic, payload)`. Planning, multi-agent dispatch, tool-failure self-healing and large-result summarisation subscribe to these events. The publishers are explicit calls in `AgentLoop.run()` and its tool hooks, so subscribers are decoupled but publication is still part of loop orchestration.
+
+| Event | Published at | Typical subscriber |
+| --- | --- | --- |
+| `TaskComplexityHigh` | plan activation check (`loop.py:595` area) | `planning/automation.py::AutoPlanManager` |
+| `ToolExecutionFailed` | after-tool hook | self-healing strategies; the returned value can replace the failed result |
+| `DataVolumeLarge` | after-tool hook (result > 5000 chars) | analyst sub-agent that replaces the payload with a summary |
+
+---
+
+## 4. Layering
+
+```text
+Entry      CLI / Dashboard (FastAPI) / Gateway / Cron
+              │  ChatRequest
+Assembly   agent/runtime.py::Runtime
+           └─ ConfigStore → provider, ToolRegistry, SkillManager,
+              MemoryManager, PluginRegistry, AgentPool, harness list
+Orchestr.  agent/loop.py::AgentLoop.run()      ← focus of this page
+           ├─ bridges: DojoStrandsModelBridge / DojoBridgedTool
+           ├─ aspects: guardrails / token compaction / turn completion / memory / plugins
+           └─ kernel : strands.Agent.invoke_async()
+Execution  tools/executor.py::ToolExecutor → sandbox policy → ToolSpec.handler
+Side       event_bus ↔ planning / multi_agent / self-healing
+```
+
+---
+
+## 5. Implementation walk-through
+
+### 5.1 The two bridges
+
+**`DojoBridgedTool` (`loop.py:72-146`)** extends `strands.types.tools.AgentTool`. `tool_spec` converts the Dojo JSON schema into a Strands `inputSchema`; `stream()` calls `ToolExecutor` and pushes the resulting `ToolResult` into `invocation_state["_dojo_tool_results"]` (`loop.py:124`) so the after-tool hook can recover `latency_ms`, `truncated`, `viz_blocks`, `artifacts`, `resource_changes`. Strands tool results are plain text, so this side channel is how structured metadata survives; results are matched back by `call_id` (`loop.py:1046-1056`).
+
+**`DojoStrandsModelBridge` (`loop.py:147-323`)** extends `strands.models.model.Model`:
+
+1. translates Strands messages back to OpenAI-style messages (`toolUse` / `toolResult` / `reasoningContent` / image blocks);
+2. runs `llm_provider.chat(..., stream=True, stream_callback=...)` in a background task, piping deltas through an `asyncio.Queue`;
+3. yields Strands `StreamEvent`s: `messageStart` → `contentBlockStart` → `contentBlockDelta`* → tool/stop blocks;
+4. **self-heals on overflow**: catches `ContextLengthExceededError`, calls `_dojo_handle_context_length_exceeded` from `invocation_state` to compact `agent.messages`, then retries once (`_dojo_context_length_retries < 1`, `loop.py:210-235`);
+5. records usage into `invocation_state["_dojo_last_usage"]`, falling back to `_estimate_tokens_rough()`.
+
+### 5.2 The seven stages of `run()`
+
+| Stage | Line | What happens |
+| --- | --- | --- |
+| 1. Build system prompt | `loop.py:544` | see list below |
+| 2. Model bridge + token ledger | `loop.py:604` | `DojoStrandsModelBridge`, `SessionTokenLedger`, `ModelContextRegistry` |
+| 3. Convert history | `loop.py:647` | Dojo history → Strands content blocks |
+| 4. Collect and bridge tools | `loop.py:743` | `_collect_tool_specs()` + plugin tools → `_sanitize_tool_specs()` → `DojoBridgedTool` |
+| 5. Assemble hooks | `loop.py:757` | memory, token compaction, turn completion, plugin bridge, guardrails |
+| 6. Instantiate Strands Agent | `loop.py:1082` | `Agent(...)` at `loop.py:1134` |
+| 7. Run and finalise | `loop.py:1146` | `invoke_async` → empty-turn recovery → harness validation → exit hooks |
+
+System prompt blocks (`loop.py:544-590`, joined with `\n\n`):
+
+```text
+1  role definition ("You are DojoAgents, a full-market finance analysis agent.")
+2  build_temporal_context_block()          current-time grounding
+3  SkillManager.prompt_block(platform)     skill index, filtered by channel
+4  MemoryManager.build_system_prompt()
+5  MemoryManager.prefetch_all(message)     memories relevant to this turn
+6  [quant]     QuantContext.prompt_block() + DojoExtensionRegistry.prompt_context()
+7  [dashboard] viz protocol + tool protocol + viz policy catalog + turn anchor
+8  [task]      TaskPromptManager.build_injection_block()
+9  build_turn_intent_anchor_async()        intent anchor extracted by a small model
+10 [multimodal] MULTIMODAL_IMAGE_PROTOCOL
+11 [attachments] SESSION_ATTACHMENTS_PROTOCOL
+```
+
+The prompt is assembled **per request**, and `request.channel` (dashboard / gateway / cli) decides which protocol blocks are injected — one kernel serves very different front ends without forking.
+
+Instantiation (`loop.py:1134`):
+
+```python
+agent = Agent(
+    model=model,                 # DojoStrandsModelBridge
+    messages=agent_messages,
+    tools=strands_tools,         # DojoBridgedTool list
+    system_prompt=system,
+    hooks=hooks,
+    plugins=plugins,
+    callback_handler=callback_handler if active_callback else None,
+    agent_id=strands_agent_id,
+    session_manager=strands_session_manager,
+)
+```
+
+Execution (`loop.py:1171`): `await agent.invoke_async(prompt=..., invocation_state=..., limits=...)`. The kernel drives multi-turn tool use; `result.metrics.cycle_count` is the iteration count and `result.stop_reason == "limit_turns"` maps to `iteration_limit`.
+
+### 5.3 Hook chain
+
+| Hook | Location | Responsibility |
+| --- | --- | --- |
+| `check_guardrails_before` | closure in `loop.py` (~920-1000) | domain argument repair (`repair_sector_tool_arguments`), harness repair/block, guardrail `before_call`, `tool_started` event |
+| `check_guardrails_after` | closure in `loop.py` (~1003-1078) | publish `ToolExecutionFailed`, publish `DataVolumeLarge`, guardrail `after_call` guidance, recover rich results, build `tool_trace` |
+| `TokenCompressionHook` | `agent/hooks/token_compression.py` | compaction decision before each model call |
+| `TurnCompletionHook` | `agent/hooks/turn_completion.py` | turn finalisation |
+| `MemoryHookProvider` | `memory/manager.py:77` | memory read/write |
+| `DojoPluginBridge` | `plugins/registry.py:499` | plugin hooks → Strands plugin |
+
+Available interventions: rewrite `event.tool_use["input"]`, rewrite `event.tool_use["name"]`, cancel with a synthetic result via `event.cancel_tool`, or abort the turn with `GuardrailHaltException` (`loop.py:65`, later recognised as `EventLoopException.__cause__`). The after-hook may rewrite `event.result["content"]`, which is how self-healing and summarisation work.
+
+### 5.4 Context and token governance
+
+| Component | Location | Role |
+| --- | --- | --- |
+| `ModelContextRegistry` | `agent/model_context.py:165` | resolve/probe each model's window (`ModelContextInfo`) |
+| `SessionTokenLedger` | `agent/token_ledger.py:72` | per-session token accounting (`SessionTokenState`) |
+| `TokenCompressionPolicy` | `agent/token_policy.py:7` | when to compact |
+| `ContextCompressor` | `agent/compressor.py:237` | how to compact: `prune_old_tool_results()` + LLM `compress()` |
+
+Three trigger paths: preventive (`TokenCompressionHook`), emergency (`ContextLengthExceededError` → compact → retry once), and per-result truncation inside `ToolExecutor`. Compaction emits `ContextCompactedEvent` (`agent/events.py:113`).
+
+### 5.5 Tool guardrails
+
+`agent/guardrails.py::ToolCallGuardrailController`: `ToolCallSignature.from_call()` (:36) normalises name+args to detect repeats; `before_call()` (:96) returns a `ToolGuardrailDecision` with `allows_execution` / `should_halt`; `after_call()` (:181) may `warn`; `toolguard_synthetic_result()` (:275) fabricates a tool result so the model sees *why* it was blocked; `append_toolguard_guidance()` (:294) appends corrective guidance. `reset_for_turn()` (:89) resets counters. Toggle: `AgentConfig.enable_guardrails`.
+
+### 5.6 Harness: pluggable domain constraints
+
+Protocol at `agent/harness.py:129`; implementations in `agent/harnesses/` (`portfolio.py`, `portfolio_eval.py`, `portfolio_task_intent.py`, `artifact_synthesis.py`, `tool_orchestrated.py`).
+
+| Method | Call site | Purpose |
+| --- | --- | --- |
+| `matches()` | `loop.py:448` | pick the active harness (first match) |
+| `repair_tool_calls()` | before-tool hook (`loop.py:974`) | fix wrong tool name/arguments |
+| `block_tool_call()` | before-tool hook (`loop.py:989`) | block out-of-order calls with a reason |
+| `validate_progress()` | finalisation (`loop.py:1288`) | was the task really completed? |
+| `build_recovery_prompt()` | finalisation (`loop.py:1292`) | drive an extra recovery turn |
+| `build_final_context()` | finalisation | enrich the final answer |
+
+State lives in `HarnessLoopState` (`harness.py:22`) with domain accessors (`created_portfolio_ids`, `target_portfolio_id`, `last_eval_submission`, …). Recovery turns are capped by `min(recovery_cap, max_iterations - 1)` (`loop.py:1285`).
+
+### 5.7 Tool layer
+
+`ToolSpec` (`tools/registry.py:9`) and `ToolRegistry` (:24, with `clone()` used to give sub-agents a trimmed tool subset); `ToolExecutor.execute_one()` handles sandbox policy, timeout, error normalisation, truncation and latency. Built-ins live in `dojoagents/tools/`: `terminal_tool`, `code_execution_tool`, `session_file_tool`, `session_input_tool`, `web_searcher`, `dojo_sdk_tool`, `mcp_tool` (+`mcp_oauth`), `skill_manage`, `plugin_manage`, `tools_list_tool`, `agent_viz`, `process_registry`, `environments/`. Tool names are sanitised for the model (`_safe_tool_name` `loop.py:1519`, `_sanitize_tool_specs` :1464) and restored afterwards (`_restore_tool_call_names` :1488). Registration happens in `runtime.py:57-231`, partly conditional (terminal / code execution by policy, delegation tool only when multi-agent is enabled).
+
+### 5.8 Skills
+
+`skills/manager.py::SkillManager`: `parse_frontmatter()` (:38), `_matches_platform()` (:64), `_matches_tool_requirements()` (:79, hides skills whose required tools are unavailable), `_get_skill_content()` (:88, cached), `prompt_block()` (:100), `list_skills()` (:163). Bodies are fetched on demand through `skills_list` / `skill_view` in `tools/skill_manage.py` — progressive disclosure in practice.
+
+### 5.9 Plugins
+
+`plugins/registry.py`: `PluginManifest` (:39), `DojoPluginContext` (:50), `DojoPluginRegistry` (:73, discovers built-in dirs plus `~/.dojo/plugins`), `DojoPluginBridge` (:499, a Strands `Plugin`). A plugin can contribute skill directories, MCP configs, tools and hooks at once.
+
+### 5.10 Planning and multi-agent
+
+**Planning** (`dojoagents/planning/`): `Plan` / `PlanStep` / `PlanStatus` / `StepType` (`models.py`), `PlanStateStore` (`store.py:14`), `PlanExecutionEngine` (`engine.py:12`), `PlanActivationHook` (`triggers.py:21`), `AutoPlanManager` (`automation.py:13`) subscribing to `TaskComplexityHigh`. The loop only checks `should_create_plan()` and publishes; if planning takes over, its result is returned directly.
+
+**Multi-agent** (`dojoagents/multi_agent/`): `AgentSpec` / `AgentRole` / `SubTask` / `AgentMessage` (`models.py`), `AgentPool` (`pool.py:15`, reuses `AgentLoop` with a cloned tool subset), `get_delegation_tool_spec(pool)` registered at `runtime.py:218`, `Orchestrator` (`orchestrator.py:19`), `MultiAgentTriggerHook` (`triggers.py:38`) and `MultiAgentAutoDispatcher` (`automation.py:10`) for event-driven dispatch.
+
+### 5.11 Resilience
+
+| Problem | Mitigation | Location |
+| --- | --- | --- |
+| Empty assistant turn | detect `last_assistant_turn_empty()`, retry once with `build_empty_assistant_recovery_prompt()`, else fall back to `empty_assistant_user_message()` | `loop.py:1186-1210`, `agent/empty_assistant.py` |
+| Reasoning leaking into content | strip `<think>` / `<thinking>` / `<reasoning>` / `<thought>`; streaming side uses `StreamingThinkScrubber` | `loop.py:1158-1166` |
+| Context overflow | compact and retry once | `loop.py:210-235` |
+| Repeated identical tool calls | guardrail signature dedup | `guardrails.py:31` |
+| Domain flow skipped | harness validation + recovery turn | `loop.py:1279-1300` |
+| Provider not configured | return `AgentResponse` with `error: no_model_configured` instead of raising | `loop.py:541` |
+| Iteration cap reached | `stop_reason == "limit_turns"` → `stopped_reason = "iteration_limit"`, still answer | `loop.py:1181` |
+
+---
+
+## 6. End-to-end sequence
+
+```text
+ChatRequest
+   ├─ [assembly] Runtime supplies provider / tools / skills / memory / plugins / harnesses
+   ├─ 1 system prompt composition
+   ├─ 2 model bridge + token ledger + context window
+   ├─ 3 history → Strands messages
+   ├─ 4 tools collected → sanitised → DojoBridgedTool
+   ├─ 5 hooks assembled
+   ├─   plan activation ── publish("TaskComplexityHigh") ──▶ planning may take over
+   ├─ 6 Agent(...) instantiated
+   └─ 7 agent.invoke_async()
+          └── Strands kernel loop ↻
+                ├─ Model.stream() → bridge → LLMProvider.chat()
+                │     └─ ContextLengthExceeded → compact → retry once
+                ├─ BeforeToolCall → arg repair / harness / guardrails / events
+                ├─ Tool.stream() → DojoBridgedTool → ToolExecutor → sandbox → handler
+                ├─ AfterToolCall → self-heal / summarise / guardrail warn / trace
+                └─ until no tool calls or limits reached
+          ↓ empty-turn recovery → think scrubbing → harness.validate_progress()
+          ↓ _run_exit_hooks() (loop.py:1348)
+       AgentResponse (content / tool_trace / metrics / stopped_reason) + event stream
+```
+
+Event types are defined in `agent/events.py` and delivered through `AgentEventSink` (:118).
+
+---
+
+## 7. Extension cheatsheet
+
+| Goal | Change this | Not this |
+| --- | --- | --- |
+| Add a tool | write a `ToolSpec`, register in `runtime.py` — see [Adding Tools](../development/adding-tools.md) | `loop.py` |
+| Add a business-flow constraint | new `agent/harnesses/xxx.py` implementing `TaskHarness` | an `if` inside `run()` |
+| Support a new model service | implement `LLMProvider`, register in `LLMProviderRegistry` | the model bridge |
+| Add prompt content | prefer a Skill; channel-specific protocol blocks go in stage 1 | the hard-coded role line |
+| Change compaction | `token_policy.py` / `compressor.py` | hook ordering |
+| Add a hook-supported interceptor | a new hook or a plugin | explicit recovery/event orchestration in the main loop |
+| Add a sub-agent role | `multi_agent/models.py::AgentSpec` + `AgentPool` | delegation call sites |
+
+---
+
+## 8. Code index
+
+| File | Key symbols | Responsibility |
+| --- | --- | --- |
+| `agent/loop.py` | `AgentLoop`(:393), `run()`(:435), `DojoStrandsModelBridge`(:147), `DojoBridgedTool`(:72), `strands_to_dojo_messages`(:324), `GuardrailHaltException`(:65), `_run_exit_hooks`(:1348) | orchestration and bridging |
+| `agent/runtime.py` | `Runtime`(:34) | dependency assembly |
+| `agent/harness.py`, `agent/harnesses/` | `TaskHarness`(:129), `HarnessLoopState`(:22) | domain constraints |
+| `agent/providers.py` | `LLMProvider`(:54), `OpenAICompatibleProvider`(:139), `get_strands_model`(:326) | model access |
+| `agent/guardrails.py` | `ToolCallGuardrailController`(:66) | tool guardrails |
+| `agent/compressor.py` | `ContextCompressor`(:237) | context compaction |
+| `agent/model_context.py`, `token_ledger.py`, `token_policy.py` | `ModelContextRegistry`, `SessionTokenLedger`, `TokenCompressionPolicy` | token governance |
+| `agent/hooks/` | `TokenCompressionHook`, `TurnCompletionHook` | loop aspects |
+| `agent/session_manager.py` | `DojoAgentSessionManager`(:144) | session persistence |
+| `agent/events.py` | `AgentEventSink`(:118) | event stream |
+| `tools/` | `ToolSpec`, `ToolRegistry`, `ToolExecutor`, `sandbox` | tool contract and execution |
+| `skills/manager.py` | `SkillManager`(:15) | skill index and lazy loading |
+| `memory/manager.py` | `MemoryManager`(:8), `MemoryHookProvider`(:77) | memory |
+| `plugins/registry.py` | `DojoPluginRegistry`(:73), `DojoPluginBridge`(:499) | plugins |
+| `planning/`, `multi_agent/` | `PlanExecutionEngine`, `AgentPool`, `Orchestrator` | planning and delegation |
+| `utils/event_bus.py` | `EventBus`(:4) | event bus |
+
+> Line numbers reflect the code at writing time; search by symbol after refactors.
+
+---
+
+## 9. Related pages
+
+- [Agent Loop](agent-loop.md) — conceptual view of a turn
+- [Runtime](runtime.md) — assembly and configuration
+- [Tools and Sandbox](tools-and-sandbox.md)
+- [Plugins](plugins.md)
+- [Multi-Agent and Planning](multi-agent-planning.md)
+- [Memory](memory.md)
+- [Event-driven](event-driven.md)
+- [Adding Tools](../development/adding-tools.md), [Repository Map](../development/repository-map.md)

--- a/docs/site/en/architecture/agent-loop.md
+++ b/docs/site/en/architecture/agent-loop.md
@@ -1,5 +1,9 @@
 # Agent Loop
 
+!!! tip "Looking for the real implementation?"
+    This page is the **conceptual** view of a turn. In code, the loop kernel is [Strands Agents](https://github.com/strands-agents/sdk-python); DojoAgents plugs its own stack in through a model bridge, a tool bridge and hooks.
+    For the full walk-through (framework choice, the seven stages of `run()`, system-prompt composition, guardrail/compaction/harness interception, code index) see **[Agent Internals](agent-internals.md)**.
+
 The agent loop coordinates model calls, tool calls, tool result feedback, and final answer generation.
 
 ## Core Objects

--- a/docs/site/en/architecture/event-driven.md
+++ b/docs/site/en/architecture/event-driven.md
@@ -12,3 +12,7 @@ Event-driven architecture decouples agents, tools, planning, multi-agent flows, 
 
 Events should include stable identifiers such as `run_id`, `seq`, timestamp, and `call_id` for tool correlation.
 
+
+## Further Reading
+
+- [Agent Internals](agent-internals.md): where the loop publishes events and how subscribers rewrite tool results.

--- a/docs/site/en/architecture/index.md
+++ b/docs/site/en/architecture/index.md
@@ -4,6 +4,7 @@ Architecture docs explain module boundaries and runtime flow. Start with [Overvi
 
 - [Runtime](runtime.md)
 - [Agent Loop](agent-loop.md)
+- [Agent Internals](agent-internals.md) (framework choice, Strands bridging, hooks/guardrails/compaction/harness at code level)
 - [Tools and Sandbox](tools-and-sandbox.md)
 - [Dashboard](dashboard.md)
 - [Gateway](gateway.md)

--- a/docs/site/en/architecture/memory.md
+++ b/docs/site/en/architecture/memory.md
@@ -13,3 +13,7 @@ Memory provides pluggable session memory, summaries, and longer-context continui
 
 Do not store provider secrets, API keys, or sensitive user configuration in memory.
 
+
+## Further Reading
+
+- [Agent Internals](agent-internals.md): how memory enters the system prompt and when `MemoryHookProvider` runs inside the loop.

--- a/docs/site/en/architecture/multi-agent-planning.md
+++ b/docs/site/en/architecture/multi-agent-planning.md
@@ -15,3 +15,7 @@ Multi-agent and planning modules support delegation, plan persistence, plan exec
 
 Multi-agent orchestration is a higher-level capability and should not replace the generic agent loop.
 
+
+## Further Reading
+
+- [Agent Internals](agent-internals.md): how explicit publishers in `AgentLoop.run()` connect planning and multi-agent subscribers through events such as `TaskComplexityHigh` and `DataVolumeLarge`.

--- a/docs/site/en/architecture/overview.md
+++ b/docs/site/en/architecture/overview.md
@@ -17,11 +17,22 @@ DojoAgents combines LLM agents, quantitative finance data, tool execution, dashb
 | `dojoagents/multi_agent/` | Agent pool and delegation |
 | `dojoagents/planning/` | Plan store, engine, tools, triggers |
 
+## Technical Foundation
+
+The agent loop kernel reuses [Strands Agents](https://github.com/strands-agents/sdk-python) (`strands-agents`). DojoAgents plugs its own providers, `ToolSpec`s, skills, memory and plugins into that kernel through a **model bridge, a tool bridge and hooks**. Model access uses the OpenAI-compatible protocol via the `openai` SDK, external tools come through `mcp`, and finance data through `dojosdk`. See [Agent Internals](agent-internals.md).
+
 ## Flow
 
 1. CLI, Dashboard, or Gateway creates a request.
 2. `Runtime` builds providers, tools, skills, memory, scheduler, and plugins from config.
-3. `AgentLoop` calls the LLM provider.
+3. `AgentLoop` composes the system prompt, bridges model and tools, and lets the Strands kernel drive multi-turn tool use.
 4. Tool calls are executed through `ToolExecutor`.
 5. `ToolResult` is sent back to the model, event stream, and dashboard UI.
+
+## Further Reading
+
+- [Runtime](runtime.md)
+- [Agent Loop](agent-loop.md)
+- [Agent Internals](agent-internals.md)
+- [Tools and Sandbox](tools-and-sandbox.md)
 

--- a/docs/site/en/architecture/plugins.md
+++ b/docs/site/en/architecture/plugins.md
@@ -18,3 +18,7 @@ Plugins let DojoAgents load tools, hooks, skills, MCP config, and agent config f
 
 Hooks must use names from `VALID_HOOKS` in `dojoagents/plugins/registry.py`.
 
+
+## Further Reading
+
+- [Agent Internals](agent-internals.md): how plugin hooks are attached to the agent loop through `DojoPluginBridge`.

--- a/docs/site/en/architecture/runtime.md
+++ b/docs/site/en/architecture/runtime.md
@@ -18,3 +18,7 @@ Runtime should not reimplement config parsing, logging, or tool execution. New c
 - Extensions: `DojoExtension`
 - Dashboard services: `dojoagents/dashboard/deps.py`
 
+
+## Further Reading
+
+- [Agent Internals](agent-internals.md): how the providers / tools / skills / memory / plugins assembled by `Runtime` are consumed by the agent loop.

--- a/docs/site/en/architecture/tools-and-sandbox.md
+++ b/docs/site/en/architecture/tools-and-sandbox.md
@@ -39,3 +39,7 @@ Tool handlers return `dict[str, Any]` or strings. Results are normalized into `T
 - [DojoSDK](../reference/dojo-sdk.md)
 - [Tasks and Pipelines](../user-guide/tasks-and-pipelines.md)
 - [Adding Tools](../development/adding-tools.md)
+
+## Further Reading
+
+- [Agent Internals](agent-internals.md): how tools are bridged into Strands tools and which hooks intercept them (argument repair, guardrails, failure self-healing, rich-result recovery).

--- a/docs/site/en/development/adding-tools.md
+++ b/docs/site/en/development/adding-tools.md
@@ -34,3 +34,7 @@ Registration: `register_dashboard_domain_tools` / `register_dashboard_portfolio_
 - Let the executor normalize result shapes.
 - Side-effect tools should return `resource_changes`.
 - Visualization tools should return `viz_blocks`.
+
+## Further Reading
+
+- [Agent Internals](../architecture/agent-internals.md): how a `ToolSpec` is bridged to the model by `DojoBridgedTool`, how structured fields such as `resource_changes` / `viz_blocks` are recovered through the `invocation_state` side channel, and how tool names are sanitised and restored.

--- a/docs/site/en/development/index.md
+++ b/docs/site/en/development/index.md
@@ -6,6 +6,7 @@ Start with:
 
 - [Repository Map](repository-map.md)
 - [Local Development](local-development.md)
+- [Known Limitations](known-limitations.md)
 - [Testing](testing.md)
 
 Extension guides:

--- a/docs/site/en/development/known-limitations.md
+++ b/docs/site/en/development/known-limitations.md
@@ -1,0 +1,77 @@
+# Known Limitations
+
+This register records confirmed, implementation-relevant gaps in the working tree based on `0d3389e`. It separates observable behavior from proposed fixes. Keep entries until a regression test demonstrates the limitation is resolved.
+
+## Status vocabulary
+
+- **Open**: confirmed in code or a reproducible run; no complete fix is present.
+- **Mitigated**: a documented workaround or boundary reduces risk, but the root limitation remains.
+- **Resolved in working tree**: code and a focused regression test are present locally; the entry can be removed after normal review.
+
+## Open limitations
+
+### DA-KI-001 — No agent-run wall-clock deadline
+
+- **Status:** Open
+- **Scope:** `DojoStrandsModelBridge.stream()`, `AgentLoop.run()`
+- **Evidence:** the bridge waits on `queue.get()` without a timeout, and model invocations are not wrapped in a run-level `asyncio.wait_for()`. Tool and selected transport operations have their own timeouts, but there is no cumulative deadline for a complete agent run.
+- **Impact:** a provider stream that neither completes nor raises can leave a run active indefinitely; iteration limits do not bound elapsed time.
+- **Workaround:** use the background-run cancellation endpoint and enforce an ingress or process-level deadline.
+- **Follow-up:** add a configurable run deadline, propagate cancellation to the model task, and test a provider that never yields a terminal result.
+
+### DA-KI-002 — Pipeline and harness budgets are not cumulative
+
+- **Status:** Open
+- **Scope:** `tasks/runtime_helpers.py::run_agent_with_tasks()`, harness recovery in `AgentLoop.run()`
+- **Evidence:** a pipeline may call the agent for up to five steps. Each pipeline step may add up to eight harness-recovery invocations, and every invocation receives the normal per-invocation `Limits`; the code does not maintain a separate cumulative turn or model-call budget for the full pipeline run.
+- **Impact:** a non-converging task can consume substantially more model/tool cycles than `agent.max_iterations` alone suggests.
+- **Workaround:** keep pipeline step counts and `max_iterations` conservative, and cancel runs that stop making observable progress.
+- **Follow-up:** introduce a shared run budget covering pipeline steps, recovery calls, model calls, tool calls and elapsed time; expose the consumed totals in response metadata.
+
+<a id="da-ki-003"></a>
+
+### DA-KI-003 — `max_content_bytes` is not enforced by web extraction
+
+- **Status:** Open
+- **Scope:** `WebToolsConfig.max_content_bytes`, `tools/web_searcher.py`
+- **Evidence:** the setting is loaded and documented, but the extractor does not consult it while reading HTTP response bodies. Character-based post-processing limits are applied only after content has been received.
+- **Impact:** a large response can consume more network bandwidth and memory than the configured byte limit implies.
+- **Workaround:** restrict extraction to trusted URLs and enforce response-size limits at an outbound proxy when needed.
+- **Follow-up:** stream response bytes, stop at the configured limit, mark truncated results, and add multibyte-content tests.
+
+### DA-KI-004 — Search results do not retain publication timestamps
+
+- **Status:** Open
+- **Scope:** `_sanitize_search_rows()`, built-in sector-attribution task
+- **Evidence:** the task requires `published_at` validation, while sanitized search rows retain only `title`, `url`, `description` and `position` even if a backend supplied a date.
+- **Impact:** the agent cannot establish the required date window from search metadata alone and may accept stale evidence unless it verifies the source content.
+- **Workaround:** call `web_extract` for candidate sources and validate the publication date from the extracted page before writing task output.
+- **Follow-up:** define a backend-neutral optional `published_at` field, preserve it in adapters and sanitization, and test date-range filtering.
+
+### DA-KI-005 — Dashboard authentication is deployment-owned
+
+- **Status:** Mitigated
+- **Scope:** Dashboard HTTP API
+- **Evidence:** routes do not perform built-in identity or role checks. The default listener is `127.0.0.1`, and [Dashboard API](../reference/dashboard-api.md#access-control-and-security-boundary) documents the boundary.
+- **Impact:** any caller that can reach the listen address can invoke chat and administrative endpoints.
+- **Workaround:** keep the service on a trusted local interface or place it behind authenticated ingress with TLS, network policy and auditing.
+- **Follow-up:** either add an optional first-party authentication mode or publish a supported authenticated deployment profile.
+
+### DA-KI-011 — Frontend lockfile resolves a vulnerable PostCSS version
+
+- **Status:** Open
+- **Scope:** Dashboard frontend build dependencies
+- **Evidence:** `npm audit` reports [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) for transitive `postcss@8.5.15`; affected versions are `<=8.5.17` and a fix is available.
+- **Impact:** processing an attacker-controlled previous source map during a frontend build may disclose arbitrary `.map` files from the build host. This is a build-time dependency risk, not evidence that the generated Dashboard bundle is directly exploitable in a browser.
+- **Workaround:** build only trusted source trees in an isolated CI environment and do not process untrusted CSS/source maps.
+- **Follow-up:** update the locked transitive dependency to a fixed PostCSS release, rerun `npm ci`, `npm audit` and `npm run build`, then retain the resulting lockfile change.
+
+## Resolved checks in this working tree
+
+| ID | Status | Correction | Regression coverage |
+| --- | --- | --- | --- |
+| DA-KI-006 | Resolved in working tree | Explicit `null` now disables a web search or extract backend instead of silently restoring the default. | `tests/test_web_searcher.py` |
+| DA-KI-007 | Resolved in working tree | Legacy portfolio data now passes through v2 before conversion to the current candidate/order schema. | `tests/dashboard/stores/test_portfolio_migration.py`, `test_portfolio_orders.py` |
+| DA-KI-008 | Resolved in working tree | Bulk kline snapshots are indexed by their `symbol` column, reused, and bypassed for explicit date windows. | `tests/dashboard/test_dojo_data_gateway.py`, `test_kline_single_day_vs_bulk.py` |
+| DA-KI-009 | Resolved in working tree | MCP sampling applies the smaller of the provider output limit and the caller's `maxTokens`. | `tests/test_mcp_advanced.py` |
+| DA-KI-010 | Resolved in working tree | Turn-intent classification is skipped when no session history exists, avoiding a model call whose result could not affect the prompt. | `tests/test_turn_intent.py`, `test_agent_harness.py` |

--- a/docs/site/en/development/repository-map.md
+++ b/docs/site/en/development/repository-map.md
@@ -4,7 +4,7 @@
 
 | Directory | Purpose |
 | --- | --- |
-| `dojoagents/agent/` | Agent loop, runtime, providers, events |
+| `dojoagents/agent/` | Agent loop, runtime, providers, events, guardrails; includes `harnesses/` (domain constraints) and `hooks/` (loop aspects) — see [Agent Internals](../architecture/agent-internals.md) |
 | `dojoagents/config/` | ConfigStore and config schema |
 | `dojoagents/tools/` | Tool registry, executor, sandbox; includes `dojo_sdk_tool.py`, web, session |
 | `dojoagents/tasks/` | Structured tasks / pipelines (contracts, TASK.md, schemas, pipelines) |
@@ -20,3 +20,5 @@
 | `docs/` | MkDocs site and `docs/plans/` design notes |
 
 Reuse `ConfigStore`, `dojoagents.logging`, `ToolRegistry`, `ToolExecutor`, and dashboard dependency accessors. Prefer `dojo.sdk.*` for agent finance reads ([DojoSDK](../reference/dojo-sdk.md)).
+
+Never write a second agent loop: reuse `AgentLoop` and the Strands kernel, and extend through tools / harnesses / hooks / plugins — see the extension cheatsheet in [Agent Internals](../architecture/agent-internals.md).

--- a/docs/site/en/getting-started/model-configuration.md
+++ b/docs/site/en/getting-started/model-configuration.md
@@ -20,9 +20,45 @@ dojoagents model --config ./agents.yaml
 
 The command lets you choose a provider, set a base URL, enter an API key, probe available models, and save the result.
 
+## Configure a custom OpenAI-compatible provider
+
+This model is exposed through an OpenAI-compatible endpoint. Add a dedicated provider to `~/.dojo/agents.yaml` and supply the API key through an environment variable:
+
+```yaml
+version: 1
+
+llm_provider:
+  default: custom-openai
+  providers:
+    custom-openai:
+      model: your-model-name
+      base_url: https://api.example.com/v1
+      api_key_env: CUSTOM_OPENAI_API_KEY
+      context_window: 128000
+      max_tokens: 8192
+
+agent:
+  model: your-model-name
+```
+
+Set the key before starting DojoAgents:
+
+```bash
+export CUSTOM_OPENAI_API_KEY="<your-api-key>"
+```
+
+`custom-openai` is a local provider ID. It can be renamed, but it must match `llm_provider.default`. `your-model-name` is sent to the endpoint as written, so preserve the casing required by the provider. When a base URL already includes `/v1`, do not append `/chat/completions`; the OpenAI SDK adds that request path.
+
+You can also run `dojoagents model`, select `Custom Endpoint`, and enter:
+
+- Custom provider name: `custom-openai`
+- Base URL: `https://api.example.com/v1`
+- Model name: `your-model-name`
+
+If the gateway does not support `/models`, the CLI falls back to manual model entry. The CLI stores an entered API key in YAML by default. To avoid storing it in plain text, remove `api_key` after setup and use `api_key_env` as shown above.
+
 ## Rules
 
 - Runtime code should read typed config through `ConfigStore.snapshot()`.
 - Dashboard/API exposure must use redacted config.
 - YAML may reference environment variables such as `${OPENAI_API_KEY}`.
-

--- a/docs/site/en/reference/configuration.md
+++ b/docs/site/en/reference/configuration.md
@@ -22,6 +22,7 @@ llm_provider:
       base_url: https://api.openai.com/v1
       api_key_env: OPENAI_API_KEY
       context_window: 128000
+      max_tokens: 32768
 
 agent:
   max_iterations: 100
@@ -104,6 +105,8 @@ sessions:
 | `multi_agent` | `MultiAgentConfig` | Multi-agent switch, worker count, default agents |
 | `planning` | `PlanConfig` | Planning tools, auto-plan threshold, plan store, max steps |
 | `sessions` | `SessionsConfig` | Runtime session storage, restore, memory sync, export directory |
+
+Set `tools.web.search_backend` or `tools.web.extract_backend` to `null` to disable that tool explicitly. Omitting a key keeps its default (`ddgs` or `fetch`). `max_content_bytes` is currently a declared limit but is not yet enforced while reading response bodies; see [DA-KI-003](../development/known-limitations.md#da-ki-003).
 
 ## Secrets
 

--- a/docs/site/en/reference/dashboard-api.md
+++ b/docs/site/en/reference/dashboard-api.md
@@ -5,6 +5,15 @@ The Dashboard API is registered by `dojoagents/dashboard/server.py` and `dojoage
 !!! note
     `/api/v1` REST route names are **not** agent `ToolSpec` names. The target finance-read path for agents is `dojo.sdk.*` (see [DojoSDK](dojo-sdk.md)). Domain tools are legacy / UI companions.
 
+## Access Control and Security Boundary
+
+The Dashboard API currently has **no built-in authentication or route-level authorization**. No route, including chat, session queries, configuration updates, or generated-memory deletion, validates a bearer token, API key, user identity, or role. Any caller that can reach the Dashboard listen address and port can send requests directly.
+
+- The CLI listens on `127.0.0.1:8765` by default, so only local processes can connect by default. This is not user-level authorization; other users or processes on the same host may still call the API.
+- With `--host 0.0.0.0`, container port publishing, a reverse proxy, or a public endpoint, any network-reachable caller may also invoke `/api/chat` and the other backend APIs.
+- CORS currently allows every origin, method, and header. CORS is a browser control, not server authentication, and does not block curl, scripts, or server-to-server requests.
+- Do not expose an unprotected Dashboard to an untrusted network. Production deployments should add authentication and authorization at the ingress layer, such as an identity-aware reverse proxy or API gateway, along with TLS, network access controls, and request auditing.
+
 ## Base Entrypoints
 
 | Method | Path | Description |
@@ -97,6 +106,47 @@ Export request body:
 ```
 
 Omit `session_id` to export all visible sessions.
+
+## Memory API
+
+### `DELETE /api/v1/memory/generated-skills`
+
+Force-clears the generated memory skill directory. The target comes from the current `memory.generated_skill_dir` setting and defaults to `~/.dojo/skills/generated`.
+
+Behavior:
+
+- Recursively deletes every file, subdirectory, and symbolic link inside the target while preserving the target directory itself.
+- Attempts to add owner read, write, and execute permissions to read-only directories before continuing.
+- Removes symbolic links without following them outside the target directory.
+- Creates an empty directory and returns `deleted_count: 0` when the target does not exist.
+- Refuses to clear the filesystem root or the current user's home directory.
+- Verifies that the directory is empty after deletion and returns an error instead of success if anything remains.
+
+This operation is irreversible and currently has no built-in authorization. Ensure that only trusted callers can reach the Dashboard before invoking it.
+
+Request:
+
+```bash
+curl -X DELETE http://127.0.0.1:8765/api/v1/memory/generated-skills
+```
+
+Successful response (HTTP 200):
+
+```json
+{
+  "ok": true,
+  "directory": "/home/user/.dojo/skills/generated",
+  "deleted_count": 3
+}
+```
+
+Error responses:
+
+| HTTP status | Scenario |
+| --- | --- |
+| `400` | Configured target is the filesystem root, home directory, a symbolic link, or not a directory |
+| `500` | Permission or filesystem failure, or entries remain after deletion |
+| `503` | The Dashboard runtime has no available `ConfigStore` |
 
 ## Domain Routers
 

--- a/docs/site/zh/architecture/agent-internals.md
+++ b/docs/site/zh/architecture/agent-internals.md
@@ -1,0 +1,404 @@
+# Agent 实现内幕
+
+> 本页回答一个此前文档没有正面回答的问题：**DojoAgents 的 Agent 能力到底是怎么搭起来的？**
+>
+> [Agent Loop](agent-loop.md) 描述的是「概念上的一轮对话」，本页描述的是「代码里真实发生的事」——用了哪个 Agent 框架、怎么桥接、系统提示词怎么拼、工具调用被谁拦截、上下文怎么压、领域逻辑挂在哪。
+>
+> 主要代码入口：`dojoagents/agent/loop.py`，重点是 `AgentLoop.run()`。本页行号只用于定位当前文档快照，稳定的引用依据是符号名。
+>
+> 证据边界：本页描述当前代码中可观察到的实现，不推断项目未记录的框架选型意图。已经确认的运行限制统一记录在[已知限制](../development/known-limitations.md)。
+
+---
+
+## 1. 一句话概括
+
+**DojoAgents 把模型与工具之间的内层循环交给 [Strands Agents](https://github.com/strands-agents/sdk-python)，而 `AgentLoop.run()` 仍负责请求编排、提示词装配、桥接、Hook、恢复、领域校验和对外事件。**
+
+```text
+        DojoAgents 自有资产                     Strands Agents 内核
+  ┌───────────────────────────┐           ┌────────────────────────┐
+  │ LLMProvider (OpenAI 兼容) │──桥接──▶ │ strands.models.Model   │
+  │ ToolSpec + ToolExecutor   │──桥接──▶ │ strands.types.AgentTool│
+  │ SkillManager / Memory     │──拼装──▶ │ system_prompt          │
+  │ Guardrails / Harness      │──挂载──▶ │ hooks (Before/After)   │
+  │ Plugins                   │──挂载──▶ │ plugins                │
+  │ DojoAgentSessionManager   │──注入──▶ │ session_manager        │
+  └───────────────────────────┘           └────────────────────────┘
+                                                    │
+                                          agent.invoke_async(...)
+                                                    │
+                                          多轮 tool-use 循环由内核驱动
+```
+
+---
+
+## 2. 用了哪些框架
+
+| 依赖 | 版本约束 | 在 Agent 能力中的角色 |
+| --- | --- | --- |
+| `strands-agents` | 不锁版本 | **Agent 事件循环内核**：多轮 tool-use 编排、消息状态机、Hook/Plugin 体系、`stop_reason`/`metrics` |
+| `strands-agents-tools` | 不锁版本 | Strands 官方工具集（按需引入） |
+| `openai` | `>=1.20,<2` | `OpenAICompatibleProvider` 的底层 SDK，也用于统计 token 与探测上下文窗口 |
+| `mcp` | `>=1.26,<2` | MCP 工具接入（`dojoagents/tools/mcp_tool.py`、`mcp_oauth.py`） |
+| `fastapi` | `>=0.110,<0.112` | Dashboard / Gateway 暴露 Agent 能力（SSE、OpenAI 兼容接口） |
+| `apscheduler` | `>=3.10,<4` | 定时任务触发 Agent 运行 |
+| `dojosdk` | `>=0.1.15` | 量化金融数据能力，包装为工具（`tools/dojo_sdk_tool.py`） |
+
+声明位置：`pyproject.toml` `dependencies` 与 `requirements.txt`。
+
+> **代码中可观察到的集成取舍。** 当前实现使用 Strands 承担模型/工具循环和 Hook 协议，同时通过适配器保留 DojoAgents 自己的 provider 与工具契约。可变的工具前后事件支持取消、改参和改结果。这些是实现事实，不代表项目已经记录了与其他框架的完整比较或选型理由。
+
+---
+
+## 3. 六条贯穿全局的设计思想
+
+### 3.1 防腐层：借内核，不被内核绑架
+
+Strands 的主要适配边界集中在 `agent/loop.py`：`DojoStrandsModelBridge`、`DojoBridgedTool`、消息转换和调用都在这里实现。少量相邻模块也直接使用 Strands 契约，包括会话管理、空回复恢复和插件桥。因此替换内核需要调整这一边界及其集成点，不能简化为只改一个桥接代码段。
+
+配套的是**双向消息翻译**：
+
+- 出站：Dojo 历史 → Strands `Messages`（`run()` 第 3 阶段，`loop.py:647` 起）
+- 入站：Strands `Messages` → Dojo 消息（`strands_to_dojo_messages()`，`loop.py:324`）
+- 压缩前再拍平一次：`compressor.flatten_messages_for_compress()` / `messages_to_strands()`
+
+### 3.2 通用循环 + 领域 Harness
+
+金融领域的强约束（组合必须先创建再回测、评测必须提交结果……）**不写进循环**，而是实现 `TaskHarness` 协议后注册进来。循环只负责在固定的 6 个时机回调它。详见 [§5.6](#harness-domain-constraints)。
+
+### 3.3 上下文经济学：渐进式披露 + 主动压缩
+
+- **技能按配置披露**：默认 `agent.lazy_skills: true` 时，`SkillManager.prompt_block()` 只注入名称/描述，正文靠 `skill_view` 按需读取；关闭懒加载时会直接注入技能正文。
+- **工具结果不全量保留**：`ContextCompressor.prune_old_tool_results()` 保留尾部 N 条，历史工具结果降级为摘要（`_summarize_tool_result()`），工具入参 JSON 截断到 150 字符（`_truncate_tool_call_args_json()`）。
+- **超限自愈**：撞到上下文上限不是报错，而是压缩后重试一次（[§5.4](#context-token-governance)）。
+
+### 3.4 混合式治理：Hook 与显式编排
+
+护栏、Token 压缩、记忆接入、回合完成和插件拦截通过 Hook/Plugin 装配；`AgentLoop.run()` 仍显式负责 Harness 解析与修复、恢复尝试、事件发布和最终响应处理。扩展或替换循环时必须同时考虑这两类治理路径。
+
+### 3.5 一切能力皆 ToolSpec
+
+技能管理、插件管理、终端、代码执行、会话文件、MCP、DojoSDK 数据、甚至**子 Agent 委派**，统一收敛为 `ToolSpec` 注册到 `ToolRegistry`。模型看到的世界是同构的，`Runtime` 只是在装配期决定往注册表里放什么。
+
+### 3.6 事件总线：解耦旁路能力
+
+`dojoagents/utils/event_bus.py::EventBus` 提供 `publish(topic, payload)`。计划编排、多智能体派发、工具失败自愈和大结果摘要通过订阅解耦；发布动作仍是 `AgentLoop.run()` 及其工具 Hook 中的显式调用，因此它属于循环编排的一部分：
+
+| 事件 | 发布位置 | 典型订阅者 |
+| --- | --- | --- |
+| `TaskComplexityHigh` | `loop.py:595` 附近（Plan 激活检查） | `planning/automation.py::AutoPlanManager` |
+| `ToolExecutionFailed` | after-tool hook | 自愈/重写策略（返回值可直接顶替失败结果） |
+| `DataVolumeLarge` | after-tool hook（结果 > 5000 字符） | 分析型子 Agent，把大结果换成摘要 |
+
+---
+
+## 4. 模块分层
+
+```text
+入口层    CLI / Dashboard(FastAPI) / Gateway / Cron
+             │  ChatRequest
+装配层    dojoagents/agent/runtime.py::Runtime
+          └─ 读 ConfigStore → 建 provider、ToolRegistry、SkillManager、
+             MemoryManager、PluginRegistry、AgentPool、Harness 列表
+编排层    dojoagents/agent/loop.py::AgentLoop.run()   ← 本页重点
+          ├─ 桥接: DojoStrandsModelBridge / DojoBridgedTool
+          ├─ 切面: guardrails / token compression / turn completion / memory / plugin
+          └─ 内核: strands.Agent.invoke_async()
+执行层    tools/executor.py::ToolExecutor → sandbox policy → ToolSpec.handler
+旁路层    event_bus ↔ planning / multi_agent / 自愈策略
+```
+
+---
+
+## 5. 关键实现拆解
+
+### 5.1 双向桥接层
+
+#### `DojoBridgedTool`（`loop.py:72-146`）
+
+继承 `strands.types.tools.AgentTool`，把一个 Dojo `ToolSpec` 包装成 Strands 工具：
+
+- `tool_spec` 属性把 Dojo 的 JSON Schema 转成 Strands 的 `inputSchema`；
+- `stream()` 内部调用 `ToolExecutor`，并把产生的 `ToolResult` 塞进 `invocation_state["_dojo_tool_results"]`（`loop.py:124`），供 after-tool hook 取回真实的 `latency_ms` / `truncated` / `viz_blocks` / `artifacts` / `resource_changes`；
+- 同时向 `event_sink` 发工具事件，驱动前端流式 UI。
+
+> 这里有一个值得注意的细节：Strands 的工具结果是纯文本 content，**结构化元数据会丢失**。DojoAgents 用 `invocation_state` 这条"侧信道"把富结果带出来，再在 hook 里按 `call_id` 匹配回收（`loop.py:1046-1056`）。
+
+#### `DojoStrandsModelBridge`（`loop.py:147-323`）
+
+继承 `strands.models.model.Model`，把任意 Dojo `LLMProvider` 变成 Strands 模型：
+
+1. `strands_to_dojo_messages()` 把 Strands 消息翻译回 OpenAI 风格消息（含 `toolUse` / `toolResult` / `reasoningContent` / 多模态图片块）；
+2. 起一个后台 task 调 `llm_provider.chat(..., stream=True, stream_callback=callback)`，用 `asyncio.Queue` 把增量文本和最终 `LLMResult` 送回；
+3. 按 Strands 的 `StreamEvent` 协议 yield：`messageStart` → `contentBlockStart` → 多个 `contentBlockDelta` → 工具块/结束块；
+4. **上下文溢出自愈**：捕获 `ContextLengthExceededError` 后，从 `invocation_state` 取出 `_dojo_handle_context_length_exceeded` 回调压缩 `agent.messages`，然后**原地重试一次**（`_dojo_context_length_retries < 1`，`loop.py:210-235`）；
+5. 顺带把 usage 写入 `invocation_state["_dojo_last_usage"]`，provider 没返回 usage 时用 `_estimate_tokens_rough()` 估算。
+
+### 5.2 `AgentLoop.run()` 的七个阶段
+
+代码里用编号注释明确分段，可按行号定位：
+
+| 阶段 | 行号 | 做什么 |
+| --- | --- | --- |
+| 1. 构建系统提示词 | `loop.py:544` | 见下方拼装清单 |
+| 2. 建模型桥 + Token 账本 | `loop.py:604` | `DojoStrandsModelBridge`、`SessionTokenLedger`、`ModelContextRegistry` 决定窗口大小 |
+| 3. 转换历史 | `loop.py:647` | Dojo 历史 → Strands `content blocks`（文本 / toolUse / reasoningContent） |
+| 4. 收集并桥接工具 | `loop.py:743` | `_collect_tool_specs()` + 插件工具 → `_sanitize_tool_specs()` → `DojoBridgedTool` |
+| 5. 装配 Hook | `loop.py:757` | memory hook、token 压缩 hook、turn completion hook、插件桥、护栏 hook |
+| 6. 实例化 Strands Agent | `loop.py:1082` | 见 `Agent(...)` 于 `loop.py:1134` |
+| 7. 运行与收尾 | `loop.py:1146` | `invoke_async` → 空回复恢复 → harness 校验 → exit hooks |
+
+**系统提示词拼装顺序**（`loop.py:544-590`，用 `\n\n` 连接非空块）：
+
+```text
+1  角色定义（"You are DojoAgents, a full-market finance analysis agent."）
+2  build_temporal_context_block()        时间上下文，防止模型用训练期日期
+3  SkillManager.prompt_block(platform)   技能索引（按 channel 平台过滤）
+4  MemoryManager.build_system_prompt()   长期记忆说明
+5  MemoryManager.prefetch_all(message)   与本轮问题相关的记忆预取
+6  [quant] QuantContext.prompt_block() + DojoExtensionRegistry.prompt_context()
+7  [dashboard] 可视化协议 + 工具协议 + 可视化策略目录 + 本轮策略锚点
+8  [task] TaskPromptManager.build_injection_block()
+9  build_turn_intent_anchor_async()      用小模型抽取本轮意图，做成锚点
+10 [多模态] MULTIMODAL_IMAGE_PROTOCOL
+11 [附件]   SESSION_ATTACHMENTS_PROTOCOL
+```
+
+> 设计要点：提示词是**按请求动态组装**的，`request.channel`（dashboard / gateway / cli）直接决定注入哪些协议块。这让同一个 Agent 内核能服务形态差异很大的前端而不需要分叉。
+
+**Agent 实例化**（`loop.py:1134`）：
+
+```python
+agent = Agent(
+    model=model,                 # DojoStrandsModelBridge
+    messages=agent_messages,     # 转换后的历史
+    tools=strands_tools,         # DojoBridgedTool 列表
+    system_prompt=system,        # 上面拼出来的字符串
+    hooks=hooks,                 # 护栏/压缩/记忆/回合完成
+    plugins=plugins,             # DojoPluginBridge
+    callback_handler=callback_handler if active_callback else None,
+    agent_id=strands_agent_id,
+    session_manager=strands_session_manager,   # DojoAgentSessionManager
+)
+```
+
+**执行**（`loop.py:1171`）：`await agent.invoke_async(prompt=..., invocation_state=..., limits=...)`。多轮 tool-use 由 Strands 内核驱动，`result.metrics.cycle_count` 即实际迭代轮数，`result.stop_reason == "limit_turns"` 映射为 DojoAgents 的 `iteration_limit`。
+
+### 5.3 Hook 拦截链
+
+| Hook | 实现位置 | 触发时机与职责 |
+| --- | --- | --- |
+| `check_guardrails_before` | `loop.py` 内闭包（约 920-1000） | 领域参数修复（`repair_sector_tool_arguments`）、harness 修复/拦截、护栏 `before_call`、发 `tool_started` 事件 |
+| `check_guardrails_after` | `loop.py` 内闭包（约 1003-1078） | 失败发 `ToolExecutionFailed`、大结果发 `DataVolumeLarge`、护栏 `after_call` 追加指导语、回收富结果、写 `tool_trace` |
+| `TokenCompressionHook` | `agent/hooks/token_compression.py` | 每轮前按 `TokenCompressionPolicy` 判断是否压缩历史 |
+| `TurnCompletionHook` | `agent/hooks/turn_completion.py` | 回合完成时的收尾（持久化/统计） |
+| `MemoryHookProvider` | `memory/manager.py:77` | 记忆的读写接入 |
+| `DojoPluginBridge` | `plugins/registry.py:499` | 把插件声明的 hook 转成 Strands plugin |
+
+**拦截能力有多强？** before-hook 里三种干预都用上了：
+
+- 改参数：`event.tool_use["input"] = repaired_args`
+- 改工具名：`event.tool_use["name"] = repaired.name`
+- 取消执行并回注合成结果：`event.cancel_tool = blocked_res["content"]`
+- 直接中止整轮：`raise GuardrailHaltException(...)`（`loop.py:65`），在外层被识别为 `EventLoopException.__cause__` 后转成优雅回复
+
+after-hook 可以**改写工具结果**（`event.result["content"] = [...]`），这是"失败自愈"和"大结果摘要化"的实现基础。
+
+<a id="context-token-governance"></a>
+
+### 5.4 上下文与 Token 治理
+
+四个组件协同：
+
+| 组件 | 位置 | 职责 |
+| --- | --- | --- |
+| `ModelContextRegistry` | `agent/model_context.py:165` | 查/探测每个模型的上下文窗口（`ModelContextInfo`） |
+| `SessionTokenLedger` | `agent/token_ledger.py:72` | 按 session 累计 token（`SessionTokenState`），支撑 `TokenUsageEvent` |
+| `TokenCompressionPolicy` | `agent/token_policy.py:7` | 判断"何时该压" |
+| `ContextCompressor` | `agent/compressor.py:237` | 执行压缩：`prune_old_tool_results()` 保尾裁头 + `compress()` 做 LLM 摘要 |
+
+三条触发路径：
+
+1. **预防式**：`TokenCompressionHook` 在每轮模型调用前按 policy 检查；
+2. **应急式**：模型桥捕获 `ContextLengthExceededError` → 压缩 → 重试一次；
+3. **结果级**：`ToolExecutor` 对超长工具输出直接截断并标记 `truncated`。
+
+压缩完成后会发出 `ContextCompactedEvent`（`agent/events.py:113`），前端可以显示"上下文已压缩"。
+
+### 5.5 工具护栏
+
+`agent/guardrails.py::ToolCallGuardrailController`：
+
+- `ToolCallSignature.from_call()`（:36）把 `工具名 + 参数` 归一化成签名，用于**识别重复调用**；
+- `before_call()`（:96）返回 `ToolGuardrailDecision`，含 `allows_execution` / `should_halt`；
+- `after_call()`（:181）根据结果与失败状态决定 `warn` / 升级；
+- `toolguard_synthetic_result()`（:275）生成"假装工具返回"的内容，让模型看到被拦截的原因而不是空洞失败；
+- `append_toolguard_guidance()`（:294）在真实结果后追加纠偏指导语。
+
+`reset_for_turn()`（:89）保证计数按回合重置。开关：`AgentConfig.enable_guardrails`。
+
+<a id="harness-domain-constraints"></a>
+
+### 5.6 Harness：领域逻辑的可插拔约束层
+
+协议定义在 `agent/harness.py:129`，实现放在 `agent/harnesses/`：
+
+```text
+harnesses/portfolio.py              组合创建/调仓流程约束
+harnesses/portfolio_eval.py         组合评测流程约束
+harnesses/portfolio_task_intent.py  组合任务意图识别
+harnesses/artifact_synthesis.py     产物合成
+harnesses/tool_orchestrated.py      纯工具编排型任务
+```
+
+`TaskHarness` 六个回调及其调用点：
+
+| 方法 | 调用点 | 作用 |
+| --- | --- | --- |
+| `matches(request, state)` | `loop.py:448` `_resolve_active_harness()` | 选出本轮生效的 harness（首个匹配） |
+| `repair_tool_calls(calls, state)` | before-tool hook（`loop.py:974`） | 纠正模型给出的错误工具名/参数 |
+| `block_tool_call(call, state)` | before-tool hook（`loop.py:989`） | 违反流程则拦截并给出原因 |
+| `validate_progress(state)` | 收尾阶段（`loop.py:1288`） | 判断任务是否真正完成 |
+| `build_recovery_prompt(decision, locale)` | 收尾阶段（`loop.py:1292`） | 未完成时生成补救提示，触发额外回合 |
+| `build_final_context(...)` | 收尾阶段 | 给最终回答补充结构化上下文 |
+
+状态载体是 `HarnessLoopState`（`harness.py:22`），它把本轮的 `tool_calls` / `tool_results` / `blocked_calls` / `tool_trace` / `final_response` 汇总起来，并提供领域快捷访问器（如 `created_portfolio_ids`、`target_portfolio_id`、`last_eval_submission`）。
+
+恢复回合有上限：`min(recovery_cap, max_iterations - 1)`（`loop.py:1285`），避免与模型互相拉锯。
+
+> **边界纪律**：`agent-loop.md` 里那句"领域逻辑不应硬编码在通用 Agent Loop 中"，落地机制就是这套 harness。新增业务约束应当新建 harness，而不是在 `run()` 里加分支。
+
+### 5.7 工具层
+
+- 契约：`tools/registry.py:9::ToolSpec`（`name` / `description` / JSON Schema / `handler`），`schema()` 输出模型可见的函数定义；
+- 注册表：`ToolRegistry`（:24），提供 `register` / `get` / `schema_list` / `all` / `clone` / `remove`，`clone()` 是**子 Agent 裁剪工具子集**的基础；
+- 执行：`tools/executor.py::ToolExecutor.execute_one()`，负责沙箱策略校验、超时、异常归一化、超长截断、`latency_ms` 统计，产出统一的 `ToolResult`；
+- 内置工具（`dojoagents/tools/`）：`terminal_tool`、`code_execution_tool`、`session_file_tool`、`session_input_tool`、`web_searcher`、`dojo_sdk_tool`、`mcp_tool`(+`mcp_oauth`)、`skill_manage`、`plugin_manage`、`tools_list_tool`、`agent_viz`、`process_registry`、`environments/`；
+- 名称安全：模型侧工具名经 `_safe_tool_name()`（`loop.py:1519`）与 `_sanitize_tool_specs()`（:1464）清洗，回填时用 `_restore_tool_call_names()`（:1488）还原真名——兼容对函数名字符集有限制的 provider。
+
+`Runtime` 在装配期把这些注册进 `ToolRegistry`（`runtime.py:57-231`），包括条件性注册（终端/代码执行受策略控制、多智能体开启时才注册 `delegation` 工具）。
+
+### 5.8 技能层（Skills）
+
+`skills/manager.py::SkillManager`：
+
+| 方法 | 行号 | 说明 |
+| --- | --- | --- |
+| `parse_frontmatter()` | :38 | 解析 `SKILL.md` 的 YAML frontmatter 与正文 |
+| `_matches_platform()` | :64 | 按 `request.channel` 平台过滤 |
+| `_matches_tool_requirements()` | :79 | 依赖工具不可用时不展示，避免模型调不存在的工具 |
+| `_get_skill_content()` | :88 | 带缓存的内容读取 |
+| `prompt_block(platform)` | :100 | 生成注入系统提示词的技能索引块 |
+| `list_skills(platform)` | :163 | 列出可用技能 |
+
+正文按需读取由 `tools/skill_manage.py` 提供的 `skills_list` / `skill_view` 工具完成——这就是 **progressive disclosure**：索引进提示词，正文进工具结果，token 花在真正用到的技能上。
+
+### 5.9 插件层
+
+`plugins/registry.py`：`PluginManifest`（:39）描述清单，`DojoPluginContext`（:50）是插件拿到的运行时句柄，`DojoPluginRegistry`（:73）负责发现（内置目录 + `~/.dojo/plugins`）与加载，`DojoPluginBridge`（:499）继承 Strands `Plugin`，把插件声明的 hook 转接到内核事件上。插件可同时贡献**技能目录、MCP 配置、工具和 hook**。
+
+### 5.10 旁路能力：Planning 与 Multi-Agent
+
+**Planning**（`dojoagents/planning/`）：`Plan` / `PlanStep` / `PlanStatus` / `StepType`（`models.py`）、`PlanStateStore`（`store.py:14`）持久化、`PlanExecutionEngine`（`engine.py:12`）执行、`PlanActivationHook`（`triggers.py:21`）判断是否需要出计划、`AutoPlanManager`（`automation.py:13`）订阅 `TaskComplexityHigh` 用 LLM 自动生成计划。主循环只在 `loop.py:595` 附近做一次 `should_create_plan()` 判断并 `publish`，**若计划流程接管则直接返回其结果**。
+
+**Multi-Agent**（`dojoagents/multi_agent/`）：`AgentSpec` / `AgentRole` / `SubTask` / `AgentMessage`（`models.py`）、`AgentPool`（`pool.py:15`）创建子 Agent（复用 `AgentLoop` + `ToolRegistry.clone()` 裁剪工具）、`get_delegation_tool_spec(pool)` 把"委派"暴露成普通工具（`runtime.py:218`）、`Orchestrator`（`orchestrator.py:19`）编排、`MultiAgentTriggerHook`（`triggers.py:38`）与 `MultiAgentAutoDispatcher`（`automation.py:10`）负责事件驱动的自动派发（例如订阅 `DataVolumeLarge` 让分析子 Agent 做摘要）。
+
+### 5.11 韧性设计（容易被忽略但很关键）
+
+| 问题 | 对策 | 位置 |
+| --- | --- | --- |
+| 模型返回空回复 | 检测 `last_assistant_turn_empty()` → 用 `build_empty_assistant_recovery_prompt()` 重试 1 次 → 仍空则回退到 `empty_assistant_user_message()` 兜底文案 | `loop.py:1186-1210`、`agent/empty_assistant.py` |
+| 思维链泄漏到正文 | 正则清洗 `<think>` / `<thinking>` / `<reasoning>` / `<thought>`，流式侧用 `StreamingThinkScrubber` | `loop.py:1158-1166`、`agent/think_scrubber.py` |
+| 上下文超限 | 压缩后重试一次 | `loop.py:210-235` |
+| 工具反复调用同一参数 | 护栏签名去重 | `guardrails.py:31` |
+| 领域流程被跳过 | harness 校验 + 恢复回合 | `loop.py:1279-1300` |
+| provider 未配置 | 提前返回带 `error: no_model_configured` 的 `AgentResponse`，不抛异常 | `loop.py:541` |
+| 迭代打满 | `stop_reason == "limit_turns"` → `stopped_reason = "iteration_limit"`，仍产出可用回答 | `loop.py:1181` |
+
+---
+
+## 6. 一次请求的完整时序
+
+```text
+ChatRequest
+   │
+   ├─ [装配] Runtime 提供 provider / tools / skills / memory / plugins / harnesses
+   │
+   ├─ 1 系统提示词拼装（时间 + 技能索引 + 记忆 + 协议块 + 意图锚点）
+   ├─ 2 模型桥 + token 账本 + 上下文窗口探测
+   ├─ 3 历史转换为 Strands 消息
+   ├─ 4 工具收集 → 名称清洗 → DojoBridgedTool
+   ├─ 5 Hook 装配（护栏 / 压缩 / 记忆 / 回合完成 / 插件）
+   ├─  Plan 激活检查 ── publish("TaskComplexityHigh") ──▶ 命中则由计划流程接管并返回
+   ├─ 6 Agent(...) 实例化
+   │
+   └─ 7 agent.invoke_async()
+          └── Strands 内核循环 ↻
+                ├─ Model.stream() ─▶ DojoStrandsModelBridge ─▶ LLMProvider.chat()
+                │      └─ ContextLengthExceeded ─▶ 压缩 ─▶ 重试一次
+                ├─ BeforeToolCall ─▶ 参数修复 / harness 拦截 / 护栏 / tool_started 事件
+                ├─ Tool.stream() ─▶ DojoBridgedTool ─▶ ToolExecutor ─▶ sandbox ─▶ handler
+                ├─ AfterToolCall ─▶ 失败自愈 / 大结果摘要 / 护栏警告 / 富结果回收 / tool_trace
+                └─ 直到无工具调用或触达 limits
+          ↓
+       空回复恢复 → think 清洗 → harness.validate_progress() → 恢复回合
+          ↓
+       _run_exit_hooks()（loop.py:1348）
+          ↓
+       AgentResponse（content / tool_trace / metrics / stopped_reason）+ 事件流
+```
+
+事件流类型见 `agent/events.py`：`ContentDeltaEvent`、`PhaseChangedEvent`、`Thinking*`、`ToolStarted/Finished`、`TokenUsageEvent`、`ContextCompactedEvent`、`RunCompleted/Failed` 等，由 `AgentEventSink`（:118）投递。
+
+---
+
+## 7. 扩展点速查
+
+| 我想做… | 应该改哪里 | 不要改哪里 |
+| --- | --- | --- |
+| 加一个新工具 | 写 `ToolSpec` 并在 `runtime.py` 注册，见 [添加工具](../development/adding-tools.md) | `loop.py` |
+| 加一条业务流程约束 | 新建 `agent/harnesses/xxx.py` 实现 `TaskHarness` | 在 `run()` 里加 if |
+| 接一个新模型服务 | 实现 `LLMProvider` 协议并注册到 `LLMProviderRegistry` | 模型桥 |
+| 加一段提示词 | 优先做成 Skill；平台专属协议块加在 `run()` 第 1 阶段 | 硬编码进角色定义 |
+| 改压缩策略 | `token_policy.py` / `compressor.py` | Hook 装配顺序 |
+| 加一个 Hook 支持的拦截 | 新建 hook 或写插件 | 主循环中的显式恢复/事件编排 |
+| 加子 Agent 角色 | `multi_agent/models.py::AgentSpec` + `AgentPool` | 委派工具的调用方 |
+
+---
+
+## 8. 代码索引
+
+| 文件 | 关键符号 | 职责 |
+| --- | --- | --- |
+| `agent/loop.py` | `AgentLoop`(:393)、`run()`(:435)、`DojoStrandsModelBridge`(:147)、`DojoBridgedTool`(:72)、`strands_to_dojo_messages`(:324)、`GuardrailHaltException`(:65)、`_run_exit_hooks`(:1348)、`_sanitize_tool_specs`(:1464) | 编排与桥接 |
+| `agent/runtime.py` | `Runtime`(:34)、`from_default_config`(:47)、`from_config_store`(:51)、`for_profile`(:360) | 依赖装配 |
+| `agent/harness.py` + `agent/harnesses/` | `TaskHarness`(:129)、`HarnessLoopState`(:22)、`HarnessDecision`(:10) | 领域约束 |
+| `agent/providers.py` | `LLMProvider`(:54)、`LLMProviderRegistry`(:69)、`OpenAICompatibleProvider`(:139)、`get_strands_model`(:326) | 模型接入 |
+| `agent/guardrails.py` | `ToolCallGuardrailController`(:66) | 工具护栏 |
+| `agent/compressor.py` | `ContextCompressor`(:237)、`flatten_messages_for_compress`(:72) | 上下文压缩 |
+| `agent/model_context.py` / `token_ledger.py` / `token_policy.py` | `ModelContextRegistry`(:165)、`SessionTokenLedger`(:72)、`TokenCompressionPolicy`(:7) | Token 治理 |
+| `agent/hooks/` | `TokenCompressionHook`、`TurnCompletionHook` | 循环切面 |
+| `agent/session_manager.py` | `DojoAgentSessionManager`(:144) | 会话持久化 |
+| `agent/events.py` | `AgentEventSink`(:118) 及各事件类 | 事件流 |
+| `tools/registry.py` / `tools/executor.py` / `tools/sandbox.py` | `ToolSpec`、`ToolRegistry`、`ToolExecutor` | 工具契约与执行 |
+| `skills/manager.py` | `SkillManager`(:15) | 技能索引与懒加载 |
+| `memory/manager.py` | `MemoryManager`(:8)、`MemoryHookProvider`(:77) | 记忆 |
+| `plugins/registry.py` | `DojoPluginRegistry`(:73)、`DojoPluginBridge`(:499) | 插件 |
+| `planning/` | `PlanExecutionEngine`(:12)、`PlanActivationHook`(:21)、`AutoPlanManager`(:13) | 计划 |
+| `multi_agent/` | `AgentPool`(:15)、`Orchestrator`(:19)、`MultiAgentAutoDispatcher`(:10) | 多智能体 |
+| `utils/event_bus.py` | `EventBus`(:4) | 事件总线 |
+
+> 行号对应撰写时的代码状态，重构后请以符号名检索为准。
+
+---
+
+## 9. 延伸阅读
+
+- [Agent Loop](agent-loop.md)：概念视角的一轮对话
+- [Runtime](runtime.md)：依赖装配与配置来源
+- [Tools 与 Sandbox](tools-and-sandbox.md)：工具契约与沙箱策略
+- [Plugins](plugins.md)：插件发现与清单
+- [Multi-Agent 与 Planning](multi-agent-planning.md)：子 Agent 与计划
+- [Memory](memory.md)：记忆 provider
+- [Event-driven](event-driven.md)：事件总线与订阅者
+- [添加工具](../development/adding-tools.md)、[仓库地图](../development/repository-map.md)

--- a/docs/site/zh/architecture/agent-loop.md
+++ b/docs/site/zh/architecture/agent-loop.md
@@ -1,5 +1,9 @@
 # Agent Loop
 
+!!! tip "想看真实实现？"
+    本页是**概念视角**的一轮对话说明。代码里的 Agent 循环内核实际上由 [Strands Agents](https://github.com/strands-agents/sdk-python) 驱动，DojoAgents 通过模型桥、工具桥和 Hook 接入自有能力。
+    完整的实现剖析（框架选型、`run()` 七阶段、系统提示词拼装、护栏/压缩/Harness 拦截链、代码索引）见 **[Agent 实现内幕](agent-internals.md)**。
+
 ## 目标
 
 Agent Loop 负责一轮或多轮模型调用、工具调用、工具结果回填和最终回答生成。

--- a/docs/site/zh/architecture/event-driven.md
+++ b/docs/site/zh/architecture/event-driven.md
@@ -21,3 +21,7 @@
 
 - [dojo.v2 协议](../reference/dojo-v2-protocol.md)
 - [Dashboard API](../reference/dashboard-api.md)
+
+## 延伸阅读
+
+- [Agent 实现内幕](agent-internals.md)：主循环在哪些位置 `publish` 事件，订阅者又如何改写工具结果。

--- a/docs/site/zh/architecture/index.md
+++ b/docs/site/zh/architecture/index.md
@@ -6,6 +6,7 @@
 
 - [Runtime](runtime.md)
 - [Agent Loop](agent-loop.md)
+- [Agent 实现内幕](agent-internals.md)（框架选型、Strands 桥接、Hook/护栏/压缩/Harness 的代码级剖析）
 - [Tools 与 Sandbox](tools-and-sandbox.md)
 - [Dashboard](dashboard.md)
 - [Gateway](gateway.md)

--- a/docs/site/zh/architecture/memory.md
+++ b/docs/site/zh/architecture/memory.md
@@ -22,3 +22,7 @@ Memory 模块为 Agent 提供可插拔的会话记忆、摘要和长期上下文
 ## 深入阅读
 
 - [Session 设计与集成](../development/session-history-design.md)
+
+## 延伸阅读
+
+- [Agent 实现内幕](agent-internals.md)：记忆如何进入系统提示词，以及 `MemoryHookProvider` 在循环中的挂载时机。

--- a/docs/site/zh/architecture/multi-agent-planning.md
+++ b/docs/site/zh/architecture/multi-agent-planning.md
@@ -25,3 +25,7 @@ Multi-Agent 不应替代通用 Agent Loop。它是更高层的编排能力，用
 
 - [Event-driven](event-driven.md)
 - [配置](../reference/configuration.md)
+
+## 延伸阅读
+
+- [Agent 实现内幕](agent-internals.md)：`AgentLoop.run()` 中的显式发布点如何通过 `TaskComplexityHigh`、`DataVolumeLarge` 等事件连接 Planning 与 Multi-Agent 订阅者。

--- a/docs/site/zh/architecture/overview.md
+++ b/docs/site/zh/architecture/overview.md
@@ -24,11 +24,15 @@ dojoagents/
 └── utils/            # Event bus and shared utilities
 ```
 
+## 技术底座
+
+Agent 循环内核复用 [Strands Agents](https://github.com/strands-agents/sdk-python)（`strands-agents`），DojoAgents 通过**模型桥 + 工具桥 + Hook**把自有的 provider、`ToolSpec`、skills、memory、plugins 接入内核；模型访问走 `openai` SDK 的 OpenAI 兼容协议，外部工具走 `mcp`，金融数据走 `dojosdk`。详见 [Agent 实现内幕](agent-internals.md)。
+
 ## 核心流程
 
 1. CLI、Dashboard 或 Gateway 构造请求。
 2. `Runtime` 从 `ConfigStore` 读取配置并组装 provider、tools、skills、memory、scheduler。
-3. `AgentLoop` 调用 LLM provider。
+3. `AgentLoop` 拼装系统提示词、桥接模型与工具，交由 Strands 内核驱动多轮 tool-use。
 4. 如果模型请求工具，`ToolExecutor` 经过 sandbox policy 后执行 `ToolSpec.handler`。
 5. 工具结果被规范化为 `ToolResult`，再进入 Agent history、事件流和 Dashboard UI。
 6. Dashboard 通过 OpenAI-compatible response 或 SSE `dojo_event` 将结果返回前端。
@@ -45,6 +49,7 @@ dojoagents/
 
 - [Runtime](runtime.md)
 - [Agent Loop](agent-loop.md)
+- [Agent 实现内幕](agent-internals.md)
 - [Tools 与 Sandbox](tools-and-sandbox.md)
 - [Dashboard](dashboard.md)
 - [Gateway](gateway.md)

--- a/docs/site/zh/architecture/plugins.md
+++ b/docs/site/zh/architecture/plugins.md
@@ -28,3 +28,7 @@ Plugin 系统允许 DojoAgents 从内置插件和用户插件目录中加载 too
 
 - [Plugin Manifest Reference](../reference/plugin-manifest.md)
 - [添加工具](../development/adding-tools.md)
+
+## 延伸阅读
+
+- [Agent 实现内幕](agent-internals.md)：插件声明的 hook 如何通过 `DojoPluginBridge` 挂载到 Agent 循环。

--- a/docs/site/zh/architecture/runtime.md
+++ b/docs/site/zh/architecture/runtime.md
@@ -26,3 +26,7 @@ Runtime 不应重复实现配置解析、日志初始化或工具执行逻辑。
 - `dojoagents/config/loader.py`
 - `dojoagents/config/models.py`
 
+
+## 延伸阅读
+
+- [Agent 实现内幕](agent-internals.md)：Runtime 装配出的 provider / tools / skills / memory / plugins，最终如何被 Agent 循环消费。

--- a/docs/site/zh/architecture/tools-and-sandbox.md
+++ b/docs/site/zh/architecture/tools-and-sandbox.md
@@ -43,3 +43,7 @@ Tools 是 Agent 执行外部动作的标准接口；Sandbox 负责在执行前�
 - [DojoSDK](../reference/dojo-sdk.md)
 - [任务与流水线](../user-guide/tasks-and-pipelines.md)
 - [添加工具](../development/adding-tools.md)
+
+## 延伸阅读
+
+- [Agent 实现内幕](agent-internals.md)：工具如何被桥接为 Strands 工具，以及调用前后被哪些 Hook 拦截（参数修复、护栏拦截、失败自愈、富结果回收）。

--- a/docs/site/zh/development/adding-tools.md
+++ b/docs/site/zh/development/adding-tools.md
@@ -46,3 +46,7 @@ ToolSpec(
 - 有副作用的工具应返回 `resource_changes`。
 - 可视化结果应返回 `viz_blocks`。
 - 阻塞 I/O 应放到 async client 或 bounded executor 中。
+
+## 延伸阅读
+
+- [Agent 实现内幕](../architecture/agent-internals.md)：`ToolSpec` 如何被 `DojoBridgedTool` 桥接给模型、`resource_changes` / `viz_blocks` 等结构化字段如何经 `invocation_state` 侧信道回收，以及工具名清洗与还原机制。

--- a/docs/site/zh/development/index.md
+++ b/docs/site/zh/development/index.md
@@ -6,6 +6,7 @@
 
 - [仓库地图](repository-map.md)
 - [本地开发](local-development.md)
+- [已知限制](known-limitations.md)
 - [测试](testing.md)
 
 扩展能力时再读：

--- a/docs/site/zh/development/known-limitations.md
+++ b/docs/site/zh/development/known-limitations.md
@@ -1,0 +1,77 @@
+# 已知限制
+
+本清单记录基于 `0d3389e` 工作树中已经确认、且与项目实现直接相关的问题，并把可观察事实与修复建议分开。只有在回归测试证明问题已解决后，才移除对应条目。
+
+## 状态定义
+
+- **Open**：已由代码或可复现运行确认，尚无完整修复。
+- **Mitigated**：已有规避方式或安全边界，但根因仍存在。
+- **Resolved in working tree**：本地已有代码修正和定向回归测试，完成常规评审后可移出清单。
+
+## 未解决限制
+
+### DA-KI-001 — Agent run 缺少总墙钟时限
+
+- **状态：** Open
+- **范围：** `DojoStrandsModelBridge.stream()`、`AgentLoop.run()`
+- **证据：** 模型桥通过没有超时的 `queue.get()` 等待结果，模型调用也没有包在 run 级 `asyncio.wait_for()` 中。工具和部分传输操作各自有超时，但完整 Agent run 没有累计 deadline。
+- **影响：** 如果 provider 流既不结束也不抛错，run 可能持续处于运行状态；迭代次数无法约束实际耗时。
+- **规避：** 使用后台 run 的取消接口，并在入口代理或进程层设置总超时。
+- **后续：** 增加可配置 run deadline，把取消信号传播到模型任务，并用永不返回终态的 provider 编写测试。
+
+### DA-KI-002 — Pipeline 与 Harness 缺少累计预算
+
+- **状态：** Open
+- **范围：** `tasks/runtime_helpers.py::run_agent_with_tasks()`、`AgentLoop.run()` 的 Harness 恢复逻辑
+- **证据：** Pipeline 最多可调用五个 Agent step，每个 step 又可能增加最多八次 Harness 恢复调用；每次调用都接收常规的单次 `Limits`，完整 pipeline run 没有独立的累计 turn 或模型调用预算。
+- **影响：** 不收敛的任务可能消耗远多于单看 `agent.max_iterations` 所预期的模型/工具循环。
+- **规避：** 保守设置 pipeline step 和 `max_iterations`，在运行不再产生可观察进展时主动取消。
+- **后续：** 引入覆盖 pipeline step、恢复调用、模型调用、工具调用和墙钟时间的共享 run budget，并在响应元数据中暴露累计消耗。
+
+<a id="da-ki-003"></a>
+
+### DA-KI-003 — Web 提取未执行 `max_content_bytes`
+
+- **状态：** Open
+- **范围：** `WebToolsConfig.max_content_bytes`、`tools/web_searcher.py`
+- **证据：** 配置已加载并写入文档，但提取器读取 HTTP 响应体时没有使用它；字符级裁剪只发生在内容接收完成之后。
+- **影响：** 大响应可能消耗超过配置含义所预期的网络流量和内存。
+- **规避：** 只提取可信 URL；有强限制要求时，在出站代理层限制响应大小。
+- **后续：** 流式读取响应字节，到达上限即停止并标记截断，同时补充多字节文本测试。
+
+### DA-KI-004 — 搜索结果没有保留发布时间
+
+- **状态：** Open
+- **范围：** `_sanitize_search_rows()`、内置板块归因任务
+- **证据：** 任务要求校验 `published_at`，但清洗后的搜索结果只保留 `title`、`url`、`description` 和 `position`，即使后端返回日期也会被丢弃。
+- **影响：** Agent 不能只依靠搜索元数据证明新闻处于目标日期窗口；若不核验正文，可能采用过期证据。
+- **规避：** 对候选来源调用 `web_extract`，从页面内容核验发布时间后再写入任务产物。
+- **后续：** 定义跨后端的可选 `published_at` 字段，在适配和清洗阶段保留它，并补充日期范围测试。
+
+### DA-KI-005 — Dashboard 身份认证由部署层承担
+
+- **状态：** Mitigated
+- **范围：** Dashboard HTTP API
+- **证据：** 路由没有内置身份或角色校验；默认监听 `127.0.0.1`，[Dashboard API](../reference/dashboard-api.md) 已说明该边界。
+- **影响：** 任何能连接监听地址的调用方都可以调用对话和管理接口。
+- **规避：** 仅监听可信本机接口，或在带 TLS、网络策略和审计的认证入口之后部署。
+- **后续：** 增加可选的一方认证模式，或提供官方支持的认证部署方案。
+
+### DA-KI-011 — 前端锁文件解析到存在漏洞的 PostCSS 版本
+
+- **状态：** Open
+- **范围：** Dashboard 前端构建依赖
+- **证据：** `npm audit` 对传递依赖 `postcss@8.5.15` 报告 [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849)；受影响范围为 `<=8.5.17`，已有可用修复。
+- **影响：** 前端构建处理攻击者控制的 previous source map 时，可能泄露构建主机上的任意 `.map` 文件。这是构建期依赖风险，不代表生成的 Dashboard bundle 已被证明可在浏览器中直接利用。
+- **规避：** 只在隔离的 CI 环境中构建可信源码，不处理不可信 CSS/source map。
+- **后续：** 把锁定的传递依赖升级到已修复的 PostCSS 版本，重新执行 `npm ci`、`npm audit` 和 `npm run build`，确认后保留锁文件变更。
+
+## 当前工作树已修正项
+
+| ID | 状态 | 修正内容 | 回归覆盖 |
+| --- | --- | --- | --- |
+| DA-KI-006 | Resolved in working tree | 显式 `null` 现在会禁用 Web search/extract 后端，不再被默认值悄悄覆盖。 | `tests/test_web_searcher.py` |
+| DA-KI-007 | Resolved in working tree | 旧版组合数据先完成 v2 中间转换，再进入当前 candidates/orders schema。 | `tests/dashboard/stores/test_portfolio_migration.py`、`test_portfolio_orders.py` |
+| DA-KI-008 | Resolved in working tree | 批量 K 线按 `symbol` 列建立并复用索引；显式日期窗口绕过快照。 | `tests/dashboard/test_dojo_data_gateway.py`、`test_kline_single_day_vs_bulk.py` |
+| DA-KI-009 | Resolved in working tree | MCP sampling 在 provider 上限与调用方 `maxTokens` 之间取较小值。 | `tests/test_mcp_advanced.py` |
+| DA-KI-010 | Resolved in working tree | 没有 session history 时跳过 turn-intent 分类，避免一次结果不可能影响提示词的模型调用。 | `tests/test_turn_intent.py`、`test_agent_harness.py` |

--- a/docs/site/zh/development/repository-map.md
+++ b/docs/site/zh/development/repository-map.md
@@ -8,7 +8,7 @@
 
 | 目录 | 说明 |
 | --- | --- |
-| `dojoagents/agent/` | Agent loop、runtime、provider、events、guardrails |
+| `dojoagents/agent/` | Agent loop、runtime、provider、events、guardrails；含 `harnesses/`（领域约束）、`hooks/`（循环切面），实现剖析见 [Agent 实现内幕](../architecture/agent-internals.md) |
 | `dojoagents/config/` | ConfigStore 和配置 schema |
 | `dojoagents/tools/` | Tool registry、executor、sandbox；含 `dojo_sdk_tool.py`、web、session |
 | `dojoagents/tasks/` | 结构化 Task / Pipeline（contract、TASK.md、schema、pipelines） |
@@ -28,6 +28,7 @@
 - 配置：`ConfigStore`
 - 日志：`dojoagents.logging`
 - 工具：`ToolRegistry`、`ToolSpec`、`ToolExecutor`
+- Agent 循环：复用 `AgentLoop` 与 Strands 内核，不要另起循环；扩展请走 tool / harness / hook / plugin（见 [Agent 实现内幕](../architecture/agent-internals.md) 的扩展点速查）
 - 金融 Agent 只读：优先 `dojo.sdk.*`（见 [DojoSDK](../reference/dojo-sdk.md)）
 - Dashboard 存储：`AtomicJsonStore`、`AtomicJsonlStore`
 - Dashboard services：通过 `dojoagents/dashboard/deps.py` 获取

--- a/docs/site/zh/getting-started/model-configuration.md
+++ b/docs/site/zh/getting-started/model-configuration.md
@@ -24,6 +24,43 @@ dojoagents model --config ./agents.yaml
 
 交互流程会引导你选择 provider、输入 base URL、输入 API key、探测模型列表，并将配置写入 YAML。
 
+## 配置自定义 OpenAI 兼容模型
+
+该模型通过 OpenAI 兼容接口接入。推荐在 `~/.dojo/agents.yaml` 中使用独立的 provider 名称，并通过环境变量提供 API key：
+
+```yaml
+version: 1
+
+llm_provider:
+  default: custom-openai
+  providers:
+    custom-openai:
+      model: your-model-name
+      base_url: https://api.example.com/v1
+      api_key_env: CUSTOM_OPENAI_API_KEY
+      context_window: 128000
+      max_tokens: 8192
+
+agent:
+  model: your-model-name
+```
+
+启动 DojoAgents 前设置密钥：
+
+```bash
+export CUSTOM_OPENAI_API_KEY="<your-api-key>"
+```
+
+这里的 `custom-openai` 是本地 provider ID，可自行命名，但必须与 `llm_provider.default` 一致；`your-model-name` 会原样发送给服务端，应保留提供方要求的大小写。如果 `base_url` 已包含 `/v1`，不要再追加 `/chat/completions`，OpenAI SDK 会自动拼接请求路径。
+
+也可以运行 `dojoagents model`，选择 `Custom Endpoint`，依次填写：
+
+- Custom provider name：`custom-openai`
+- Base URL：`https://api.example.com/v1`
+- Model name：`your-model-name`
+
+如果网关不支持 `/models` 探测，CLI 会提示手动输入模型名。CLI 默认会把输入的 API key 写入 YAML；如需避免明文保存，配置完成后删除 `api_key`，改用上例的 `api_key_env`。
+
 ## 配置原则
 
 - 运行时代码读取配置时应通过 `ConfigStore.snapshot()`。
@@ -33,4 +70,3 @@ dojoagents model --config ./agents.yaml
 ## 下一步
 
 完成模型配置后，阅读 [第一次 Agent 运行](first-agent-run.md)。
-

--- a/docs/site/zh/reference/configuration.md
+++ b/docs/site/zh/reference/configuration.md
@@ -22,6 +22,7 @@ llm_provider:
       base_url: https://api.openai.com/v1
       api_key_env: OPENAI_API_KEY
       context_window: 128000
+      max_tokens: 32768
 
 agent:
   max_iterations: 100
@@ -104,6 +105,8 @@ sessions:
 | `multi_agent` | `MultiAgentConfig` | 多智能体开关、worker 数和默认 agent 定义 |
 | `planning` | `PlanConfig` | plan 工具开关、自动规划阈值、plan store 和最大 step |
 | `sessions` | `SessionsConfig` | runtime session 存储、恢复、memory 同步和导出目录 |
+
+把 `tools.web.search_backend` 或 `tools.web.extract_backend` 显式设为 `null` 可以禁用对应工具；省略字段时继续使用默认值（`ddgs` 或 `fetch`）。`max_content_bytes` 目前只是已声明的限制，读取响应体时尚未执行，详见 [DA-KI-003](../development/known-limitations.md#da-ki-003)。
 
 ## 敏感字段
 

--- a/docs/site/zh/reference/dashboard-api.md
+++ b/docs/site/zh/reference/dashboard-api.md
@@ -5,6 +5,15 @@ Dashboard API 由 `dojoagents/dashboard/server.py` 和 `dojoagents/dashboard/rou
 !!! note
     `/api/v1` 的 REST 路由名 **不等于** Agent `ToolSpec` 名。Agent 金融只读的目标主路径是 `dojo.sdk.*`（见 [DojoSDK](dojo-sdk.md)）。Domain tools 为 legacy / UI 配套。
 
+## 访问控制与安全边界
+
+当前 Dashboard API **没有内置身份认证或接口级授权**。所有路由（包括对话、session 查询、配置修改以及删除 generated memory）均不校验 Bearer token、API key、用户身份或角色。只要调用方能够连接 Dashboard 的监听地址和端口，就可以直接发起请求。
+
+- CLI 默认监听 `127.0.0.1:8765`，因此默认只有本机进程可以连接；这不是用户级鉴权，同一主机上的其他用户或进程仍可能调用。
+- 如果使用 `--host 0.0.0.0`、容器端口映射、反向代理或公网入口，网络可达的调用方也可以调用 `/api/chat` 和其他后端接口。
+- CORS 当前允许任意 origin、method 和 header。CORS 只约束浏览器，不是服务端鉴权，也不能阻止 curl、脚本或服务端请求。
+- 不要把未加保护的 Dashboard 直接暴露到不可信网络。生产部署应在入口层增加认证和授权（例如带身份校验的反向代理或 API gateway）、TLS、网络访问控制和请求审计。
+
 ## 基础入口
 
 | Method | Path | 说明 |
@@ -97,6 +106,47 @@ Session API 由 `chat_sessions` router 挂在 `/api/v1/chat/sessions`。
 ```
 
 不传 `session_id` 时导出所有可见 session。
+
+## Memory API
+
+### `DELETE /api/v1/memory/generated-skills`
+
+强制清空 generated memory skill 目录。目标目录来自当前配置的 `memory.generated_skill_dir`，默认值为 `~/.dojo/skills/generated`。
+
+接口行为：
+
+- 递归删除目标目录中的所有文件、子目录和符号链接，但保留目标目录本身。
+- 遇到只读目录时尝试为 owner 补充读、写、执行权限后继续删除。
+- 符号链接本身会被删除，但不会跟随链接删除目标目录之外的内容。
+- 目标目录不存在时会创建空目录，并返回 `deleted_count: 0`。
+- 拒绝清空文件系统根目录或当前用户 Home 目录。
+- 删除后再次检查目录；存在残留时返回错误，不会报告成功。
+
+该操作不可恢复，并且当前没有内置鉴权。调用前应确保 Dashboard 仅对可信调用方可达。
+
+请求：
+
+```bash
+curl -X DELETE http://127.0.0.1:8765/api/v1/memory/generated-skills
+```
+
+成功响应（HTTP 200）：
+
+```json
+{
+  "ok": true,
+  "directory": "/home/user/.dojo/skills/generated",
+  "deleted_count": 3
+}
+```
+
+错误响应：
+
+| HTTP 状态 | 场景 |
+| --- | --- |
+| `400` | 配置目录是根目录、Home 目录、符号链接或非目录 |
+| `500` | 权限、文件系统错误，或删除后仍有残留 |
+| `503` | Dashboard runtime 没有可用的 `ConfigStore` |
 
 ## Domain Routers
 

--- a/dojoagents/agent/providers.py
+++ b/dojoagents/agent/providers.py
@@ -139,10 +139,29 @@ class StaticLLMProvider:
 class OpenAICompatibleProvider:
     name = "openai"
 
-    def __init__(self, *, api_key: str | None = None, base_url: str | None = None, author: str | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        author: str | None = None,
+        max_tokens: int | None = None,
+    ) -> None:
         self.api_key = api_key
         self.base_url = base_url
         self.author = author
+        self.max_tokens = max_tokens
+
+    @staticmethod
+    def _reasoning_text(message: Any) -> str:
+        for field in ("reasoning_content", "reasoning"):
+            reasoning = getattr(message, field, None)
+            if isinstance(reasoning, str) and reasoning:
+                return reasoning
+        model_extra = getattr(message, "model_extra", None)
+        if isinstance(model_extra, dict):
+            return str(model_extra.get("reasoning_content") or model_extra.get("reasoning") or "")
+        return ""
 
     @staticmethod
     def _usage_dict(usage: Any) -> dict[str, int] | None:
@@ -191,6 +210,8 @@ class OpenAICompatibleProvider:
                 "tools": [{"type": "function", "function": tool} for tool in tools] or None,
                 "stream": stream,
             }
+            if self.max_tokens is not None:
+                create_kwargs["max_tokens"] = self.max_tokens
             if stream:
                 create_kwargs["stream_options"] = {"include_usage": True}
             response = await client.chat.completions.create(**create_kwargs)
@@ -231,9 +252,7 @@ class OpenAICompatibleProvider:
                     continue
                 choice = chunk.choices[0]
                 delta = choice.delta
-                reasoning_delta = getattr(delta, "reasoning_content", None) or (
-                    delta.model_extra.get("reasoning_content") if hasattr(delta, "model_extra") and delta.model_extra else None
-                )
+                reasoning_delta = self._reasoning_text(delta)
                 if reasoning_delta:
                     full_reasoning.append(reasoning_delta)
                 content_delta = delta.content or ""
@@ -277,9 +296,7 @@ class OpenAICompatibleProvider:
             )
         else:
             message = response.choices[0].message
-            reasoning_content = getattr(message, "reasoning_content", None) or (
-                message.model_extra.get("reasoning_content") if hasattr(message, "model_extra") and message.model_extra else None
-            )
+            reasoning_content = self._reasoning_text(message)
             final_tool_calls = []
             if message.tool_calls:
                 for tc in message.tool_calls:

--- a/dojoagents/agent/runtime.py
+++ b/dojoagents/agent/runtime.py
@@ -265,6 +265,7 @@ class Runtime:
                 api_key=provider_cfg.api_key,
                 base_url=provider_cfg.base_url,
                 author=provider_cfg.author,
+                max_tokens=provider_cfg.max_tokens,
             )
             provider.name = provider_name or "openai"
             LOGGER.info(

--- a/dojoagents/agent/turn_intent.py
+++ b/dojoagents/agent/turn_intent.py
@@ -229,5 +229,10 @@ async def build_turn_intent_anchor_async(
     *,
     model: str,
 ) -> tuple[str, TurnIntentResult]:
+    # There is nothing to classify as a continuation when the request has no
+    # prior turns.  Avoid an unnecessary model call whose result would be
+    # discarded by build_turn_intent_anchor() anyway.
+    if not request.metadata.get("history"):
+        return "", DEFAULT_TURN_INTENT
     intent = await classify_turn_intent(request, llm_provider, model=model)
     return build_turn_intent_anchor(request, intent), intent

--- a/dojoagents/config/loader.py
+++ b/dojoagents/config/loader.py
@@ -101,6 +101,7 @@ def _provider_config(name: str, raw: dict[str, Any]) -> LLMProviderConfig:
     if not api_key and api_key_env:
         api_key = os.getenv(str(api_key_env))
     context_window = raw.get("context_window")
+    max_tokens = raw.get("max_tokens")
     raw_model = _as_non_empty_string(raw.get("model"))
     parsed_author, parsed_model = _split_author_and_model(raw_model)
     author = _as_non_empty_string(raw.get("author")) or parsed_author or _DEFAULT_PROVIDER_AUTHORS.get(name, "")
@@ -111,6 +112,7 @@ def _provider_config(name: str, raw: dict[str, Any]) -> LLMProviderConfig:
         api_key_env=api_key_env,
         api_key=api_key,
         context_window=int(context_window) if context_window is not None else None,
+        max_tokens=int(max_tokens) if max_tokens is not None else None,
     )
 
 
@@ -180,8 +182,8 @@ def _to_config(raw: dict[str, Any]) -> AgentsConfig:
             timeout_seconds=float(sandbox_raw.get("timeout_seconds", 120)),
         ),
         web=WebToolsConfig(
-            search_backend=web_raw.get("search_backend") or "ddgs",
-            extract_backend=web_raw.get("extract_backend") or "fetch",
+            search_backend=web_raw.get("search_backend", "ddgs"),
+            extract_backend=web_raw.get("extract_backend", "fetch"),
             user_agent=web_raw.get("user_agent"),
             search_base_url=web_raw.get("search_base_url"),
             extract_base_url=web_raw.get("extract_base_url"),

--- a/dojoagents/config/models.py
+++ b/dojoagents/config/models.py
@@ -16,6 +16,7 @@ class LLMProviderConfig:
     api_key_env: str | None = None
     api_key: str | None = None
     context_window: int | None = None
+    max_tokens: int | None = None
 
 
 @dataclass(frozen=True)
@@ -52,8 +53,8 @@ class SandboxConfig:
 
 @dataclass(frozen=True)
 class WebToolsConfig:
-    search_backend: str = "ddgs"
-    extract_backend: str = "fetch"
+    search_backend: str | None = "ddgs"
+    extract_backend: str | None = "fetch"
     user_agent: str | None = None
     search_base_url: str | None = None
     extract_base_url: str | None = None

--- a/dojoagents/dashboard/routers/memory.py
+++ b/dojoagents/dashboard/routers/memory.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Request
+from fastapi.concurrency import run_in_threadpool
+from fastapi.responses import JSONResponse
+
+from dojoagents.dashboard.schemas.memory import ClearGeneratedMemoryResponse
+from dojoagents.dashboard.services.generated_memory_service import (
+    GeneratedMemoryService,
+    UnsafeGeneratedMemoryPathError,
+)
+from dojoagents.logging import LOGGER
+
+router = APIRouter(prefix="/memory", tags=["memory"])
+
+
+@router.delete("/generated-skills", response_model=ClearGeneratedMemoryResponse)
+async def clear_generated_memory(request: Request) -> Any:
+    store = getattr(request.app.state, "config_store", None)
+    if store is None:
+        return JSONResponse(
+            status_code=503,
+            content={"error": "Configuration store not available"},
+        )
+
+    generated_skill_dir = store.snapshot().memory.generated_skill_dir
+    service = GeneratedMemoryService(generated_skill_dir)
+    try:
+        directory, deleted_count = await run_in_threadpool(service.clear)
+    except UnsafeGeneratedMemoryPathError as exc:
+        return JSONResponse(status_code=400, content={"error": str(exc)})
+    except OSError as exc:
+        LOGGER.exception("Failed to clear generated memory directory %s", generated_skill_dir)
+        return JSONResponse(
+            status_code=500,
+            content={"error": f"Failed to clear generated memory: {exc}"},
+        )
+
+    return ClearGeneratedMemoryResponse(
+        directory=str(directory),
+        deleted_count=deleted_count,
+    )

--- a/dojoagents/dashboard/schemas/memory.py
+++ b/dojoagents/dashboard/schemas/memory.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class ClearGeneratedMemoryResponse(BaseModel):
+    ok: bool = True
+    directory: str
+    deleted_count: int

--- a/dojoagents/dashboard/server.py
+++ b/dojoagents/dashboard/server.py
@@ -21,6 +21,7 @@ from dojoagents.dashboard.routers import (
     chat_sessions,
     market,
     markets,
+    memory,
     portfolio,
     sector,
     sectors,
@@ -112,6 +113,7 @@ def _sync_runtime_agent_from_config(runtime: Any, provider_name: str | None) -> 
             api_key=provider_cfg.api_key,
             base_url=provider_cfg.base_url,
             author=provider_cfg.author,
+            max_tokens=provider_cfg.max_tokens,
         )
         llm_provider.name = selected_provider
     LOGGER.info(
@@ -396,6 +398,7 @@ def create_app(
     app.include_router(markets.router, prefix="/api/v1")
     app.include_router(sectors.router, prefix="/api/v1")
     app.include_router(chat_sessions.router, prefix="/api/v1")
+    app.include_router(memory.router, prefix="/api/v1")
 
     app.add_middleware(
         CORSMiddleware,

--- a/dojoagents/dashboard/services/dojo_data_gateway.py
+++ b/dojoagents/dashboard/services/dojo_data_gateway.py
@@ -120,6 +120,39 @@ class DojoDataGateway:
     def kline_index_ready(self) -> bool:
         return self._kline_symbol_index is not None
 
+    async def warm_kline_index(self) -> None:
+        """Load the bulk kline snapshot once and index rows by symbol."""
+        if self._kline_symbol_index is not None:
+            return
+        async with self._kline_index_lock:
+            if self._kline_symbol_index is not None:
+                return
+            payload_df = await self._call(
+                "stock_all_klines",
+                self.client.stocks.get_all_klines_with_df(),
+            )
+            if not isinstance(payload_df, pd.DataFrame):
+                raise GatewayBadResponseError(
+                    "stock_all_klines: upstream response is not a DataFrame"
+                )
+
+            symbol_index: dict[str, pd.DataFrame] = {}
+            if "symbol" in payload_df.columns:
+                normalized = payload_df.copy()
+                normalized["symbol"] = normalized["symbol"].map(
+                    lambda value: _canonical_symbol(str(value))
+                )
+                for symbol, rows in normalized.groupby("symbol", sort=False):
+                    symbol_index[symbol] = rows.copy()
+            else:
+                for raw_symbol in payload_df.index.unique():
+                    symbol = _canonical_symbol(str(raw_symbol))
+                    rows = payload_df.loc[[raw_symbol]].copy()
+                    if "symbol" not in rows.columns:
+                        rows.insert(0, "symbol", symbol)
+                    symbol_index[symbol] = rows
+            self._kline_symbol_index = symbol_index
+
     async def _call(self, operation: str, awaitable: Any) -> Any:
         try:
             return await awaitable
@@ -164,39 +197,35 @@ class DojoDataGateway:
         **window: Any,
     ) -> GatewayResult["pd.DataFrame"]:
         kwargs = {key: value for key, value in window.items() if value is not None}
+        canonical_symbols = [_canonical_symbol(symbol) for symbol in symbols]
+
+        # A bulk snapshot cannot be assumed to cover an arbitrary date range.
+        if kwargs.get("start_time") is not None or kwargs.get("end_time") is not None:
+            return await self._fetch_klines_per_symbol(canonical_symbols, kwargs)
 
         try:
-            payload_df = await self._call(
-                "stock_klines",
-                self.client.stocks.get_all_klines_with_df(),
-            )
-            canonical_symbols = [_canonical_symbol(symbol) for symbol in symbols if _canonical_symbol(symbol) in payload_df.index]
-            df = payload_df.loc[canonical_symbols]
-            if kwargs.get("start_time"):
-                df = df[df.bar_time >= kwargs.get("start_time")]
-            if kwargs.get("end_time"):
-                df = df[df.bar_time <= kwargs.get("end_time")]
-            if limit := kwargs.get("limit"):
-                limit = int(limit)
-                df = df.iloc[-limit:]
-            return _df_result(df)
-        except Exception:
-            pass
+            await self.warm_kline_index()
+        except GatewayError:
+            return await self._fetch_klines_per_symbol(canonical_symbols, kwargs)
 
-        async def fetch_one(symbol: str) -> GatewayResult[list[dict[str, Any]]]:
-            payload = await self._call(
-                "stock_klines",
-                self.client.stocks.get_kline(symbol=_canonical_symbol(symbol), **kwargs),
-            )
-            return _list_result(payload, "stock_klines", "klines")
-
-        results = await asyncio.gather(*(fetch_one(s) for s in symbols), return_exceptions=True)
-        rows: list[dict[str, Any]] = []
-        for res in results:
-            if isinstance(res, Exception):
+        index = self._kline_symbol_index or {}
+        limit = int(kwargs["limit"]) if kwargs.get("limit") is not None else None
+        frames: list[pd.DataFrame] = []
+        missing: list[str] = []
+        for symbol in canonical_symbols:
+            frame = index.get(symbol)
+            if frame is None:
+                missing.append(symbol)
                 continue
-            rows.extend(res.data)
-        return _df_result(pd.DataFrame(rows))
+            frames.append(frame.iloc[-limit:] if limit is not None else frame)
+
+        if missing:
+            fallback = await self._fetch_klines_per_symbol(missing, kwargs)
+            if not fallback.data.empty:
+                frames.append(fallback.data)
+        if not frames:
+            return _df_result(pd.DataFrame())
+        return _df_result(pd.concat(frames, ignore_index=True))
 
     async def _fetch_kline_rows(self, symbols: list[str], kwargs: dict[str, Any]) -> list[dict[str, Any]]:
         async def fetch_one(symbol: str) -> list[dict[str, Any]]:
@@ -229,15 +258,18 @@ class DojoDataGateway:
         symbols: list[str] | None = None,
     ) -> GatewayResult["pd.DataFrame"]:
         try:
-            payload_df = await self._call(
-                "stock_all_klines",
-                self.client.stocks.get_all_klines_with_df(),
+            await self.warm_kline_index()
+            index = self._kline_symbol_index or {}
+            selected = (
+                list(index)
+                if symbols is None
+                else [_canonical_symbol(symbol) for symbol in symbols]
             )
-            if symbols is not None:
-                canonical_symbols = [_canonical_symbol(symbol) for symbol in symbols if _canonical_symbol(symbol) in payload_df.index]
-                payload_df = payload_df.loc[canonical_symbols]
-            return _df_result(payload_df)
-        except Exception:
+            frames = [index[symbol] for symbol in selected if symbol in index]
+            if not frames:
+                return _df_result(pd.DataFrame())
+            return _df_result(pd.concat(frames, ignore_index=True))
+        except GatewayError:
             pass
 
         kwargs: dict[str, Any] = {}

--- a/dojoagents/dashboard/services/generated_memory_service.py
+++ b/dojoagents/dashboard/services/generated_memory_service.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import shutil
+import stat
+from pathlib import Path
+
+
+class UnsafeGeneratedMemoryPathError(ValueError):
+    """Raised when a configured generated-memory directory is unsafe to clear."""
+
+
+class GeneratedMemoryService:
+    def __init__(self, generated_skill_dir: str | Path) -> None:
+        self.generated_skill_dir = Path(generated_skill_dir).expanduser()
+
+    def clear(self) -> tuple[Path, int]:
+        target = self.generated_skill_dir
+        self._validate_target(target)
+
+        if not target.exists():
+            target.mkdir(parents=True, exist_ok=True)
+            return target.resolve(), 0
+        if target.is_symlink() or not target.is_dir():
+            raise UnsafeGeneratedMemoryPathError(
+                f"Generated memory path must be a real directory: {target}"
+            )
+
+        self._make_owner_writable(target)
+        deleted_count = 0
+        for child in target.iterdir():
+            if child.is_symlink() or not child.is_dir():
+                child.unlink()
+            else:
+                shutil.rmtree(child, onexc=self._force_remove)
+            deleted_count += 1
+
+        remaining = list(target.iterdir())
+        if remaining:
+            names = ", ".join(path.name for path in remaining)
+            raise OSError(f"Generated memory directory is not empty after deletion: {names}")
+        return target.resolve(), deleted_count
+
+    @staticmethod
+    def _make_owner_writable(path: Path) -> None:
+        mode = path.stat().st_mode
+        required = stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR
+        if mode & required != required:
+            path.chmod(mode | required)
+
+    @classmethod
+    def _force_remove(cls, function, path: str, _excinfo) -> None:
+        target = Path(path)
+        cls._make_owner_writable(target)
+        function(path)
+
+    @staticmethod
+    def _validate_target(target: Path) -> None:
+        absolute = target.absolute()
+        home = Path.home().absolute()
+        if absolute == Path(absolute.anchor) or absolute == home:
+            raise UnsafeGeneratedMemoryPathError(
+                f"Refusing to clear unsafe generated memory path: {target}"
+            )

--- a/dojoagents/dashboard/services/portfolio_store.py
+++ b/dojoagents/dashboard/services/portfolio_store.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import threading
 import uuid
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, List, Optional
 
@@ -194,7 +194,10 @@ class PortfolioStore:
     @staticmethod
     def _to_v2(payload: dict[str, Any]) -> dict[str, Any]:
         migrated = dict(payload)
-        migrated["version"] = STORE_VERSION
+        # Keep this intermediate document at v2.  Marking it as the current
+        # version would make _normalize_document() discard legacy holdings
+        # before they can be converted to v3 candidates.
+        migrated["version"] = 2
         migrated.setdefault("pinned", False)
         holdings = migrated.get("holdings")
         normalized_holdings: list[dict[str, Any]] = []

--- a/dojoagents/dashboard/web/src/components/settings/SettingsModal.tsx
+++ b/dojoagents/dashboard/web/src/components/settings/SettingsModal.tsx
@@ -262,7 +262,15 @@ function buildForm(cfg: SettingsConfig): SettingsFormState {
   const providers: Record<string, ProviderForm> = {};
 
   for (const name of KNOWN_PROVIDERS) {
-    providers[name] = { model: '', author: '', base_url: '', api_key_env: '', api_key: '' };
+    providers[name] = {
+      model: '',
+      author: '',
+      base_url: '',
+      api_key_env: '',
+      api_key: '',
+      context_window: null,
+      max_tokens: null,
+    };
   }
 
   for (const [name, value] of Object.entries(asRecord(llm.providers))) {
@@ -273,12 +281,28 @@ function buildForm(cfg: SettingsConfig): SettingsFormState {
       base_url: asString(provider.base_url),
       api_key_env: asString(provider.api_key_env),
       api_key: provider.api_key === '***' ? '' : asString(provider.api_key),
+      context_window:
+        provider.context_window === null || provider.context_window === undefined
+          ? null
+          : asNumber(provider.context_window, 32768),
+      max_tokens:
+        provider.max_tokens === null || provider.max_tokens === undefined
+          ? null
+          : asNumber(provider.max_tokens, 4096),
     });
   }
 
   const defaultProvider = asString(llm.default, 'openai');
   if (!providers[defaultProvider]) {
-    providers[defaultProvider] = { model: '', author: '', base_url: '', api_key_env: '', api_key: '' };
+    providers[defaultProvider] = {
+      model: '',
+      author: '',
+      base_url: '',
+      api_key_env: '',
+      api_key: '',
+      context_window: null,
+      max_tokens: null,
+    };
   }
 
   const agent = asRecord(cfg.agent);
@@ -383,7 +407,16 @@ function buildPatch(form: SettingsFormState): SettingsConfig {
   const providers: Record<string, unknown> = {};
   for (const [name, rawProvider] of Object.entries(form.llm_provider.providers)) {
     const provider = normalizeProviderForm(name, rawProvider);
-    if (!provider.model && !provider.author && !provider.base_url && !provider.api_key_env && !provider.api_key && name !== form.llm_provider.default) {
+    if (
+      !provider.model &&
+      !provider.author &&
+      !provider.base_url &&
+      !provider.api_key_env &&
+      !provider.api_key &&
+      provider.context_window === null &&
+      provider.max_tokens === null &&
+      name !== form.llm_provider.default
+    ) {
       continue;
     }
     const next: Record<string, unknown> = { model: provider.model };
@@ -391,6 +424,8 @@ function buildPatch(form: SettingsFormState): SettingsConfig {
     if (provider.base_url) next.base_url = provider.base_url;
     if (provider.api_key_env) next.api_key_env = provider.api_key_env;
     if (provider.api_key) next.api_key = provider.api_key;
+    if (provider.context_window !== null) next.context_window = provider.context_window;
+    if (provider.max_tokens !== null) next.max_tokens = provider.max_tokens;
     providers[name] = next;
   }
 
@@ -731,6 +766,18 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
                       </Field>
                       <Field label="Author">
                         {textInput(provider.author, () => {}, providerDefaultAuthor(name), 'text', true)}
+                      </Field>
+                      <Field label="Context Window">
+                        {numberInput(provider.context_window ?? 0, (value) =>
+                          updateField((draft) => {
+                            draft.llm_provider.providers[name].context_window = value > 0 ? value : null;
+                          }), 0)}
+                      </Field>
+                      <Field label="Max Output Tokens">
+                        {numberInput(provider.max_tokens ?? 0, (value) =>
+                          updateField((draft) => {
+                            draft.llm_provider.providers[name].max_tokens = value > 0 ? value : null;
+                          }), 0)}
                       </Field>
                       <Field label="API Key Env">
                         {textInput(provider.api_key_env, (value) =>

--- a/dojoagents/dashboard/web/src/types/settings.ts
+++ b/dojoagents/dashboard/web/src/types/settings.ts
@@ -4,6 +4,8 @@ export interface ProviderForm {
   base_url: string;
   api_key_env: string;
   api_key: string;
+  context_window: number | null;
+  max_tokens: number | null;
 }
 
 export interface SettingsFormState {

--- a/dojoagents/tools/mcp_tool.py
+++ b/dojoagents/tools/mcp_tool.py
@@ -148,10 +148,21 @@ class SamplingHandler:
             provider = UnconfiguredLLMProvider()
             model = ""
         else:
+            configured_max = getattr(provider_cfg, "max_tokens", None)
+            if not isinstance(configured_max, int) or configured_max <= 0:
+                configured_max = None
+            requested_max = getattr(params, "maxTokens", None)
+            if not isinstance(requested_max, int) or requested_max <= 0:
+                requested_max = None
+            if configured_max is not None and requested_max is not None:
+                max_tokens = min(configured_max, requested_max)
+            else:
+                max_tokens = configured_max or requested_max
             provider = OpenAICompatibleProvider(
                 api_key=provider_cfg.api_key,
                 base_url=provider_cfg.base_url,
-                author=provider_cfg.author,
+                author=getattr(provider_cfg, "author", None),
+                max_tokens=max_tokens,
             )
             model = provider_cfg.model or ""
 
@@ -275,6 +286,9 @@ class MCPServerTask:
         sampling_handler = SamplingHandler(self.name, self.config)
 
         if url or self.config.get("transport") == "sse":
+            # 与生产路径一致：显式导入，便于单测 patch `mcp.client.sse.sse_client`
+            from mcp.client.sse import sse_client
+
             headers = self.config.get("headers", {})
 
             oauth_auth = None

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,10 +46,12 @@ plugins:
             任务与流水线: Tasks and Pipelines
             架构: Architecture
             总览: Overview
+            Agent 实现内幕: Agent Internals
             配置: Configuration
             开发: Development
             仓库地图: Repository Map
             本地开发: Local Development
+            已知限制: Known Limitations
             测试: Testing
             添加工具: Adding Tools
             添加 Dashboard 路由: Adding Dashboard Routes
@@ -88,6 +90,7 @@ nav:
       - 总览: architecture/overview.md
       - Runtime: architecture/runtime.md
       - Agent Loop: architecture/agent-loop.md
+      - Agent 实现内幕: architecture/agent-internals.md
       - Tools 与 Sandbox: architecture/tools-and-sandbox.md
       - Dashboard: architecture/dashboard.md
       - Gateway: architecture/gateway.md
@@ -110,6 +113,7 @@ nav:
       - development/index.md
       - 仓库地图: development/repository-map.md
       - 本地开发: development/local-development.md
+      - 已知限制: development/known-limitations.md
       - 测试: development/testing.md
       - Session 设计与集成: development/session-history-design.md
       - 添加工具: development/adding-tools.md

--- a/tests/dashboard/routers/conftest.py
+++ b/tests/dashboard/routers/conftest.py
@@ -105,6 +105,10 @@ class KlineStore:
 
 
 class StockStore:
+    def resolve(self, ticker, market=None):
+        resolved_market = market or self.find_market(ticker)
+        return self.get(resolved_market, ticker.strip().upper())
+
     def get(self, market, ticker):
         return SimpleNamespace(market=market, ticker=ticker)
 
@@ -164,6 +168,9 @@ class PortfolioService:
         return True
 
     async def add_holding(self, _portfolio_id, _body):
+        return self.detail
+
+    async def add_holdings_batch(self, _portfolio_id, _bodies):
         return self.detail
 
     async def auto_allocate(self, _portfolio_id, _body):

--- a/tests/dashboard/routers/test_memory.py
+++ b/tests/dashboard/routers/test_memory.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import stat
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import yaml
+from fastapi.testclient import TestClient
+
+from dojoagents.config.loader import ConfigStore
+from dojoagents.dashboard.server import create_app
+
+
+def _make_client(tmp_path, generated_skill_dir) -> TestClient:
+    config_path = tmp_path / "agents.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "memory": {
+                    "provider": "skill_summary",
+                    "generated_skill_dir": str(generated_skill_dir),
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    runtime = SimpleNamespace(
+        agent=None,
+        config_store=ConfigStore(path=str(config_path)),
+        extensions=MagicMock(),
+        scheduler=MagicMock(),
+    )
+    runtime.extensions.status.return_value = []
+    runtime.scheduler.list_jobs.return_value = []
+    return TestClient(create_app(runtime))
+
+
+def test_clear_generated_memory_removes_contents_and_keeps_directory(tmp_path):
+    generated_dir = tmp_path / "generated"
+    skill_dir = generated_dir / "generated-session"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("memory", encoding="utf-8")
+    (generated_dir / ".skills_cache.json").write_text("{}", encoding="utf-8")
+    client = _make_client(tmp_path, generated_dir)
+
+    response = client.delete("/api/v1/memory/generated-skills")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "ok": True,
+        "directory": str(generated_dir.resolve()),
+        "deleted_count": 2,
+    }
+    assert generated_dir.is_dir()
+    assert list(generated_dir.iterdir()) == []
+
+
+def test_clear_generated_memory_is_idempotent_when_directory_is_missing(tmp_path):
+    generated_dir = tmp_path / "missing" / "generated"
+    client = _make_client(tmp_path, generated_dir)
+
+    response = client.delete("/api/v1/memory/generated-skills")
+
+    assert response.status_code == 200
+    assert response.json()["deleted_count"] == 0
+    assert generated_dir.is_dir()
+
+
+def test_clear_generated_memory_unlinks_symlink_without_following_it(tmp_path):
+    generated_dir = tmp_path / "generated"
+    generated_dir.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    protected = outside / "keep.txt"
+    protected.write_text("keep", encoding="utf-8")
+    (generated_dir / "linked").symlink_to(outside, target_is_directory=True)
+    client = _make_client(tmp_path, generated_dir)
+
+    response = client.delete("/api/v1/memory/generated-skills")
+
+    assert response.status_code == 200
+    assert response.json()["deleted_count"] == 1
+    assert protected.read_text(encoding="utf-8") == "keep"
+
+
+def test_clear_generated_memory_removes_read_only_tree(tmp_path):
+    generated_dir = tmp_path / "generated"
+    skill_dir = generated_dir / "generated-read-only"
+    skill_dir.mkdir(parents=True)
+    skill_file = skill_dir / "SKILL.md"
+    skill_file.write_text("memory", encoding="utf-8")
+    skill_file.chmod(stat.S_IRUSR)
+    skill_dir.chmod(stat.S_IRUSR | stat.S_IXUSR)
+    generated_dir.chmod(stat.S_IRUSR | stat.S_IXUSR)
+    client = _make_client(tmp_path, generated_dir)
+
+    response = client.delete("/api/v1/memory/generated-skills")
+
+    assert response.status_code == 200
+    assert response.json()["deleted_count"] == 1
+    assert list(generated_dir.iterdir()) == []
+
+
+def test_clear_generated_memory_rejects_home_directory(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "dojoagents.dashboard.services.generated_memory_service.Path.home",
+        lambda: tmp_path,
+    )
+    client = _make_client(tmp_path, tmp_path)
+
+    response = client.delete("/api/v1/memory/generated-skills")
+
+    assert response.status_code == 400
+    assert "unsafe generated memory path" in response.json()["error"]
+
+
+def test_clear_generated_memory_without_config_store_returns_503():
+    runtime = SimpleNamespace(
+        agent=None,
+        config_store=None,
+        extensions=MagicMock(),
+        scheduler=MagicMock(),
+    )
+    runtime.extensions.status.return_value = []
+    runtime.scheduler.list_jobs.return_value = []
+    client = TestClient(create_app(runtime))
+
+    response = client.delete("/api/v1/memory/generated-skills")
+
+    assert response.status_code == 503

--- a/tests/dashboard/stores/test_portfolio_migration.py
+++ b/tests/dashboard/stores/test_portfolio_migration.py
@@ -32,12 +32,17 @@ def _write_v1(root) -> tuple[object, bytes]:
     return path, path.read_bytes()
 
 
-def test_v1_portfolio_load_does_not_mutate_detail_file(tmp_path) -> None:
+def test_v1_portfolio_load_normalizes_in_memory_without_mutating_detail_file(tmp_path) -> None:
     path, original = _write_v1(tmp_path)
 
     store = PortfolioStore(tmp_path)
 
-    assert store.get_raw("p1")["version"] == 1
+    payload = store.get_raw("p1")
+    assert payload["version"] == 3
+    assert payload["candidates"] == [
+        {"ticker": "AAPL", "market": "us", "added_at": payload["candidates"][0]["added_at"]}
+    ]
+    assert payload["orders"] == []
     assert path.read_bytes() == original
 
 
@@ -54,23 +59,22 @@ def test_portfolio_migration_dry_run_reports_without_writing(tmp_path) -> None:
     assert not (path.parent / "p1.json.v1.bak").exists()
 
 
-def test_portfolio_migration_backs_up_and_applies_v2_mapping(tmp_path) -> None:
+def test_portfolio_migration_backs_up_and_applies_current_mapping(tmp_path) -> None:
     path, original = _write_v1(tmp_path)
     store = PortfolioStore(tmp_path)
 
     report = store.migrate_to_v2(dry_run=False)
 
     payload = json.loads(path.read_text(encoding="utf-8"))
-    holding = payload["holdings"][0]
     assert report["migrated"] == ["p1"]
-    assert payload["version"] == 2
+    assert payload["version"] == 3
     assert payload["pinned"] is False
-    assert holding["shares_locked"] is True
-    assert holding["open_date_locked"] is False
-    assert holding["cost_override"] is None
-    assert holding["cost_locked"] is False
+    assert payload["candidates"][0]["ticker"] == "AAPL"
+    assert payload["candidates"][0]["market"] == "us"
+    assert payload["orders"] == []
+    assert "holdings" not in payload
     assert (path.parent / "p1.json.v1.bak").read_bytes() == original
-    assert json.loads((path.parent / "index.json").read_text(encoding="utf-8"))["version"] == 2
+    assert json.loads((path.parent / "index.json").read_text(encoding="utf-8"))["version"] == 3
 
 
 def test_corrupt_portfolio_is_reported_and_preserved(tmp_path) -> None:

--- a/tests/test_agent_loop_integrated.py
+++ b/tests/test_agent_loop_integrated.py
@@ -169,8 +169,8 @@ async def test_integrated_history_formatting_and_reasoning():
     await loop.run(ChatRequest(user_id="local", session_id="s1", message="What now?", metadata={"history": history}))
 
     # Inspect the messages sent to the LLM
-    assert len(llm.calls) == 1
-    sent_messages = llm.calls[0]["messages"]
+    assert len(llm.calls) == 2
+    sent_messages = llm.calls[-1]["messages"]
 
     # system message, 2 history messages, and 1 user message
     # Let's check history assistant message:
@@ -393,6 +393,6 @@ async def test_history_tool_calls_enriched_from_provider_state() -> None:
         )
     )
 
-    sent_messages = llm.calls[0]["messages"]
+    sent_messages = llm.calls[-1]["messages"]
     assistant_msg = next(message for message in sent_messages if message["role"] == "assistant")
     assert assistant_msg["tool_calls"][0]["metadata"]["native_model_content"]["parts"][0]["functionCall"]["thoughtSignature"] == "sig-prev"

--- a/tests/test_built_in_plugins.py
+++ b/tests/test_built_in_plugins.py
@@ -10,18 +10,6 @@ def _clear_plugin_registry_state() -> None:
     reg._manifests.clear()
 
 
-def test_built_in_example_plugin_loads():
-    _clear_plugin_registry_state()
-    reg = get_plugin_registry()
-    reg.discover_and_load(force=True)
-    assert "example_plugin" in reg._plugins
-
-    # Test Hook
-    res = reg.invoke_hook("pre_llm_call", session_id="s1", user_message="hello")
-    assert any("提示：插件已挂载并开始监听本轮对话。" in r for r in res)
-    assert reg.invoke_hook("transform_llm_output", response_text="hello", session_id="s1") == []
-
-
 def test_built_in_project_guardian_blocks_malicious_commands():
     _clear_plugin_registry_state()
     reg = get_plugin_registry()

--- a/tests/test_cli_gateway_setup.py
+++ b/tests/test_cli_gateway_setup.py
@@ -80,7 +80,7 @@ async def test_wechat_qr_login_client_uses_async_httpx(monkeypatch):
     assert calls[1]["headers"]["ilink-app-id"] == "bot"
 
 
-def test_gateway_setup_single_adapter_writes_config(tmp_path, monkeypatch, capsys):
+def test_gateway_setup_single_adapter_writes_config(tmp_path, monkeypatch, caplog):
     from dojoagents.cli.main import main
 
     config_path = tmp_path / "agents.yaml"
@@ -97,7 +97,7 @@ def test_gateway_setup_single_adapter_writes_config(tmp_path, monkeypatch, capsy
         "bot_token": "telegram-token",
         "home_channel": "123456",
     }
-    output = capsys.readouterr().out + capsys.readouterr().err
+    output = caplog.text
     assert "Telegram configured" in output
     assert str(config_path) in output
 
@@ -151,7 +151,7 @@ def test_gateway_setup_all_adapters_writes_every_hook(tmp_path, monkeypatch):
     assert fake_wechat.started is True
 
 
-def test_gateway_setup_wechat_uses_qr_url_flow(tmp_path, monkeypatch, capsys):
+def test_gateway_setup_wechat_uses_qr_url_flow(tmp_path, monkeypatch, capsys, caplog):
     from dojoagents.cli.gateway_setup import configure_gateway_adapters
 
     config_path = tmp_path / "agents.yaml"
@@ -171,7 +171,7 @@ def test_gateway_setup_wechat_uses_qr_url_flow(tmp_path, monkeypatch, capsys):
     assert hook["dm_policy"] == "open"
     assert hook["group_policy"] == "disabled"
     assert hook["home_channel"] == "manual-home"
-    output = capsys.readouterr().out + capsys.readouterr().err
+    output = capsys.readouterr().out + caplog.text
     assert "WeChat QR login URL: https://login.example/qr" in output
     assert "WeChat configured via QR login" in output
 

--- a/tests/test_config_multi_agent_plan.py
+++ b/tests/test_config_multi_agent_plan.py
@@ -13,6 +13,27 @@ from dojoagents.config.loader import _to_config, resolve_provider_config
 from dojoagents.config.models import LLMConfig, LLMProviderConfig
 
 
+def test_llm_provider_parses_max_tokens() -> None:
+    config = _to_config(
+        {
+            "llm_provider": {
+                "default": "finance-gateway",
+                "providers": {
+                    "finance-gateway": {
+                        "model": "DeepSeek-V4-Flash",
+                        "context_window": 1_000_000,
+                        "max_tokens": 384_000,
+                    }
+                },
+            }
+        }
+    )
+
+    provider = config.llm_provider.providers["finance-gateway"]
+    assert provider.context_window == 1_000_000
+    assert provider.max_tokens == 384_000
+
+
 class TestMultiAgentConfig:
     def test_defaults(self):
         cfg = MultiAgentConfig()

--- a/tests/test_dashboard_chat_openai.py
+++ b/tests/test_dashboard_chat_openai.py
@@ -182,6 +182,63 @@ def test_sync_runtime_agent_from_config_uses_native_gemini_provider():
     assert isinstance(runtime.agent.llm_provider, GeminiNativeProvider)
 
 
+def test_sync_runtime_agent_from_config_preserves_openai_provider_limits():
+    from dojoagents.agent.model_context import ModelContextRegistry
+    from dojoagents.agent.providers import OpenAICompatibleProvider
+    from dojoagents.config.models import AgentConfig, AgentsConfig, LLMConfig, LLMProviderConfig
+    from dojoagents.dashboard.server import _sync_runtime_agent_from_config
+
+    class FakeStore:
+        def snapshot(self):
+            return AgentsConfig(
+                llm_provider=LLMConfig(
+                    default="model-router",
+                    providers={
+                        "model-router": LLMProviderConfig(
+                            model="glm-5.2",
+                            author="z-ai",
+                            base_url="https://openrouter.ai/api/v1",
+                            api_key="test-key",
+                            context_window=1_048_576,
+                            max_tokens=384_000,
+                        )
+                    },
+                ),
+                agent=AgentConfig(
+                    model="old-model",
+                    compression_threshold_ratio=0.75,
+                    session_max_tokens_cap=500_000,
+                    default_context_window=65_536,
+                ),
+            )
+
+    class FakeAgent:
+        def __init__(self):
+            self.llm_provider = None
+            self.provider_config = None
+            self.config = AgentConfig(model="old-model")
+            self.model_context_registry = None
+
+    runtime = MagicMock()
+    runtime.config_store = FakeStore()
+    runtime.agent = FakeAgent()
+
+    model = _sync_runtime_agent_from_config(runtime, "model-router")
+
+    assert model == "glm-5.2"
+    assert isinstance(runtime.agent.llm_provider, OpenAICompatibleProvider)
+    assert runtime.agent.llm_provider.name == "model-router"
+    assert runtime.agent.llm_provider.author == "z-ai"
+    assert runtime.agent.llm_provider.max_tokens == 384_000
+    assert runtime.agent.provider_config.context_window == 1_048_576
+    assert runtime.agent.config.model == "glm-5.2"
+    assert runtime.agent.config.compression_threshold_ratio == 0.75
+    assert runtime.agent.config.session_max_tokens_cap == 500_000
+    assert runtime.agent.config.default_context_window == 65_536
+    assert isinstance(runtime.agent.model_context_registry, ModelContextRegistry)
+    assert runtime.agent.model_context_registry.default_context_window == 65_536
+
+
 # ── Non-streaming /api/chat tests ────────────────────────────────────
 
 

--- a/tests/test_dashboard_config_update.py
+++ b/tests/test_dashboard_config_update.py
@@ -246,6 +246,38 @@ def test_put_config_updates_web_tool_settings(tmp_path):
     assert body["tools"]["sandbox"]["timeout_seconds"] == 120
 
 
+def test_put_config_syncs_agent_model_from_new_default_provider(tmp_path):
+    runtime, cfg_file = _make_runtime_with_config(
+        tmp_path,
+        {
+            "version": 1,
+            "llm_provider": {
+                "default": "openai",
+                "providers": {
+                    "openai": {"model": "gpt-4.1"},
+                    "model-router": {
+                        "model": "glm-5.2",
+                        "author": "z-ai",
+                    },
+                },
+            },
+            "agent": {"model": "gpt-4.1", "max_iterations": 8},
+        },
+    )
+    client = TestClient(create_app(runtime))
+
+    response = client.put(
+        "/api/config",
+        json={"llm_provider": {"default": "model-router"}},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["agent"]["model"] == "glm-5.2"
+    saved = yaml.safe_load(cfg_file.read_text(encoding="utf-8"))
+    assert saved["agent"]["model"] == "glm-5.2"
+    assert saved["agent"]["max_iterations"] == 8
+
+
 def test_get_config_still_works_after_put(tmp_path):
     """GET /api/config reflects changes made by PUT."""
     runtime, _ = _make_runtime_with_config(

--- a/tests/test_gateway_state.py
+++ b/tests/test_gateway_state.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 from dojoagents.agent.models import ChatRequest
-from dojoagents.gateway.state import GatewaySessionStore, GatewaySession
+from dojoagents.gateway.state import GatewaySessionStore
 from dojoagents.gateway.adapters.base import GatewayEvent
 
 
@@ -92,7 +92,6 @@ async def test_agent_loop_prepends_history_from_request_metadata():
     from dojoagents.dojo_extensions.registry import DojoExtensionRegistry
     from dojoagents.memory.manager import MemoryManager
     from dojoagents.skills.manager import SkillManager
-    from dojoagents.tools.executor import ToolExecutor
     from unittest.mock import MagicMock
 
     llm = StaticLLMProvider([LLMResult(content="Mocked answer")])
@@ -133,8 +132,8 @@ async def test_agent_loop_prepends_history_from_request_metadata():
     await loop.run(request)
 
     # Inspect messages sent to the LLM
-    assert len(llm.calls) == 1
-    messages = llm.calls[0]["messages"]
+    assert len(llm.calls) == 2
+    messages = llm.calls[-1]["messages"]
     
     # Assert system prompt is present
     assert messages[0]["role"] == "system"
@@ -226,4 +225,3 @@ async def test_gateway_runner_sqlite_integration(tmp_path):
     assert history[1]["content"] == "I am Paris"
 
     await runner.stop()
-

--- a/tests/test_mcp_advanced.py
+++ b/tests/test_mcp_advanced.py
@@ -31,12 +31,6 @@ def test_sanitize_error():
 @pytest.mark.asyncio
 async def test_circuit_breaker():
     from dojoagents.tools.mcp_tool import (
-        _server_error_counts,
-        _server_breaker_opened_at,
-        _CIRCUIT_BREAKER_THRESHOLD,
-        _CIRCUIT_BREAKER_COOLDOWN_SEC,
-        _bump_server_error,
-        _reset_server_error,
         make_mcp_tool_handler,
     )
     import dojoagents.tools.mcp_tool as mcp_tool
@@ -154,3 +148,103 @@ async def test_sse_oauth_and_sampling():
         res = await handler(None, params)
         assert res.content.text == "Hello from Dojo LLM"
         assert res.model == "gpt-4"
+
+
+@pytest.mark.asyncio
+async def test_sampling_handler_preserves_provider_routing_and_output_limit():
+    from dojoagents.agent.models import LLMResult
+    from dojoagents.config.models import AgentsConfig, LLMConfig, LLMProviderConfig
+    from dojoagents.tools.mcp_tool import SamplingHandler
+    from mcp.types import CreateMessageRequestParams, SamplingMessage, TextContent
+
+    config = AgentsConfig(
+        llm_provider=LLMConfig(
+            default="model-router",
+            providers={
+                "model-router": LLMProviderConfig(
+                    model="example-model",
+                    author="example-author",
+                    base_url="https://api.example.com/v1",
+                    api_key="test-key",
+                    max_tokens=8_192,
+                )
+            },
+        )
+    )
+    params = CreateMessageRequestParams(
+        messages=[
+            SamplingMessage(
+                role="user",
+                content=TextContent(type="text", text="analyze"),
+            )
+        ],
+        maxTokens=100,
+    )
+
+    with patch("dojoagents.config.loader.ConfigStore.snapshot", return_value=config), patch(
+        "dojoagents.agent.providers.OpenAICompatibleProvider"
+    ) as provider_cls:
+        provider_cls.return_value.chat = AsyncMock(
+            return_value=LLMResult(content="done")
+        )
+        response = await SamplingHandler("example", {})(None, params)
+
+    provider_cls.assert_called_once_with(
+        api_key="test-key",
+        base_url="https://api.example.com/v1",
+        author="example-author",
+        max_tokens=100,
+    )
+    provider_cls.return_value.chat.assert_awaited_once()
+    assert provider_cls.return_value.chat.await_args.kwargs["model"] == "example-model"
+    assert response.content.text == "done"
+
+
+@pytest.mark.asyncio
+async def test_production_mcp_handler_returns_content_and_resets_breaker():
+    import dojoagents.tools.mcp_tool as mcp_tool
+    from dojoagents.tools.mcp_tool import make_mcp_tool_handler
+
+    class FakeMCPClient:
+        async def call_tool_async(self, **kwargs):
+            assert kwargs["name"] == "quote"
+            assert kwargs["arguments"] == {"ticker": "AAPL"}
+            assert kwargs["tool_use_id"].startswith("tooluse_")
+            return {
+                "status": "success",
+                "content": [{"type": "text", "text": "189.25"}],
+            }
+
+    task = MagicMock()
+    task.name = "market"
+    task.mcp_client = FakeMCPClient()
+    mcp_tool._server_error_counts["market"] = 2
+
+    result = await make_mcp_tool_handler(task, "quote")({"ticker": "AAPL"})
+
+    assert result == {
+        "content": "189.25",
+        "metadata": {"server": "market", "mcp_tool": "quote"},
+    }
+    assert mcp_tool._server_error_counts["market"] == 0
+
+
+@pytest.mark.asyncio
+async def test_production_mcp_handler_redacts_error_and_trips_breaker():
+    import dojoagents.tools.mcp_tool as mcp_tool
+    from dojoagents.tools.mcp_tool import make_mcp_tool_handler
+
+    class FailingMCPClient:
+        async def call_tool_async(self, **_kwargs):
+            raise RuntimeError("request failed with API_KEY=secret-value")
+
+    task = MagicMock()
+    task.name = "private-market"
+    task.mcp_client = FailingMCPClient()
+    mcp_tool._reset_server_error(task.name)
+    handler = make_mcp_tool_handler(task, "quote")
+
+    with pytest.raises(Exception, match=r"request failed with \[REDACTED\]"):
+        await handler({})
+
+    assert mcp_tool._server_error_counts[task.name] == 1

--- a/tests/test_openai_provider_usage.py
+++ b/tests/test_openai_provider_usage.py
@@ -40,6 +40,102 @@ async def test_openai_provider_stream_usage():
 
 
 @pytest.mark.asyncio
+async def test_openai_provider_builds_minimal_compatible_stream_request() -> None:
+    provider = OpenAICompatibleProvider(
+        api_key="test-key",
+        base_url="https://api.example.com/v1",
+        max_tokens=8192,
+    )
+    messages = [{"role": "user", "content": "分析市场"}]
+    tools = [
+        {
+            "name": "market.quote",
+            "description": "查询行情",
+            "parameters": {"type": "object", "properties": {}},
+        }
+    ]
+
+    async def _stream():
+        yield MagicMock(
+            choices=[
+                MagicMock(
+                    delta=MagicMock(
+                        content="完成",
+                        tool_calls=None,
+                        reasoning_content=None,
+                        reasoning=None,
+                        model_extra=None,
+                    )
+                )
+            ],
+            usage=None,
+        )
+
+    with patch("openai.AsyncOpenAI") as client_cls:
+        client_cls.return_value.chat.completions.create = AsyncMock(return_value=_stream())
+        await provider.chat(
+            messages,
+            tools,
+            model="Example-Model",
+            stream=True,
+            stream_callback=lambda _: None,
+        )
+
+    kwargs = client_cls.return_value.chat.completions.create.await_args.kwargs
+    assert kwargs == {
+        "model": "Example-Model",
+        "messages": messages,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "max_tokens": 8192,
+        "tools": [{"type": "function", "function": tools[0]}],
+    }
+    for forbidden_key in (
+        "reasoning_effort",
+        "reasoning",
+        "thinking",
+        "temperature",
+        "prompt_cache_key",
+        "extra_body",
+    ):
+        assert forbidden_key not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_model_router_prefixes_author_without_double_prefixing() -> None:
+    provider = OpenAICompatibleProvider(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        author="z-ai",
+    )
+    provider.name = "model-router"
+    response = MagicMock(
+        choices=[
+            MagicMock(
+                message=MagicMock(
+                    content="ok",
+                    tool_calls=None,
+                    reasoning_content=None,
+                    reasoning=None,
+                    model_extra=None,
+                )
+            )
+        ],
+        usage=None,
+    )
+
+    with patch("openai.AsyncOpenAI") as client_cls:
+        client_cls.return_value.chat.completions.create = AsyncMock(return_value=response)
+        await provider.chat([], [], model="glm-5.2", stream=False)
+        first_model = client_cls.return_value.chat.completions.create.await_args.kwargs["model"]
+        await provider.chat([], [], model="z-ai/glm-5.2", stream=False)
+        second_model = client_cls.return_value.chat.completions.create.await_args.kwargs["model"]
+
+    assert first_model == "z-ai/glm-5.2"
+    assert second_model == "z-ai/glm-5.2"
+
+
+@pytest.mark.asyncio
 async def test_openai_provider_raises_context_length_exceeded():
     from dojoagents.agent.context_length import ContextLengthExceededError
 
@@ -69,3 +165,96 @@ async def test_openai_provider_preserves_tool_call_metadata_non_stream() -> None
 
     assert result.tool_calls[0].metadata["thought_signature"] == "sig-1"
     assert result.tool_calls[0].metadata["tool_call_extra"]["providerTag"] == "gemini"
+
+
+@pytest.mark.asyncio
+async def test_openai_provider_preserves_tool_call_metadata_stream() -> None:
+    provider = OpenAICompatibleProvider(api_key="test-key", base_url="http://example")
+
+    async def _stream():
+        function = MagicMock(
+            name="portfolio_read_list",
+            arguments='{"market":',
+            model_extra={"thoughtSignature": "sig-stream"},
+        )
+        yield MagicMock(
+            choices=[
+                MagicMock(
+                    delta=MagicMock(
+                        content="",
+                        tool_calls=[
+                            MagicMock(
+                                index=0,
+                                id="call-stream",
+                                function=function,
+                                model_extra={"providerTag": "gemini"},
+                            )
+                        ],
+                        reasoning_content=None,
+                        reasoning=None,
+                        model_extra=None,
+                    )
+                )
+            ],
+            usage=None,
+        )
+        yield MagicMock(
+            choices=[
+                MagicMock(
+                    delta=MagicMock(
+                        content="",
+                        tool_calls=[
+                            MagicMock(
+                                index=0,
+                                id=None,
+                                function=MagicMock(
+                                    name=None,
+                                    arguments='"us"}',
+                                    model_extra=None,
+                                ),
+                                model_extra=None,
+                            )
+                        ],
+                        reasoning_content=None,
+                        reasoning=None,
+                        model_extra=None,
+                    )
+                )
+            ],
+            usage=None,
+        )
+
+    with patch("openai.AsyncOpenAI") as client_cls:
+        client_cls.return_value.chat.completions.create = AsyncMock(return_value=_stream())
+        result = await provider.chat(
+            [],
+            [],
+            model="gpt-4.1",
+            stream=True,
+            stream_callback=lambda _text: None,
+        )
+
+    tool_call = result.tool_calls[0]
+    assert tool_call.arguments == {"market": "us"}
+    assert tool_call.metadata["thought_signature"] == "sig-stream"
+    assert tool_call.metadata["tool_call_extra"]["providerTag"] == "gemini"
+
+
+@pytest.mark.asyncio
+async def test_openai_provider_parses_reasoning_response_field() -> None:
+    provider = OpenAICompatibleProvider(api_key="test-key", base_url="http://example")
+    message = MagicMock(
+        content="最终答案",
+        tool_calls=None,
+        reasoning_content=None,
+        reasoning="思考过程",
+        model_extra=None,
+    )
+    response = MagicMock(choices=[MagicMock(message=message)], usage=None)
+
+    with patch("openai.AsyncOpenAI") as client_cls:
+        client_cls.return_value.chat.completions.create = AsyncMock(return_value=response)
+        result = await provider.chat([], [], model="DeepSeek-V4-Flash", stream=False)
+
+    assert result.content == "最终答案"
+    assert result.metadata["reasoning_content"] == "思考过程"

--- a/tests/test_runtime_multi_agent_plan.py
+++ b/tests/test_runtime_multi_agent_plan.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 from dojoagents.config.models import AgentsConfig, LLMConfig, LLMProviderConfig, MultiAgentConfig, PlanConfig
 from dojoagents.config.loader import ConfigStore
 from dojoagents.agent.gemini_provider import GeminiNativeProvider
+from dojoagents.agent.providers import OpenAICompatibleProvider
 from dojoagents.agent.runtime import Runtime
 
 
@@ -46,6 +47,33 @@ class TestRuntimeGeminiProvider:
         )
         rt = Runtime.from_config_store(_make_store(config))
         assert isinstance(rt.agent.llm_provider, GeminiNativeProvider)
+
+
+class TestRuntimeOpenAICompatibleProvider:
+    def test_runtime_preserves_provider_routing_and_output_limit(self):
+        config = AgentsConfig(
+            llm_provider=LLMConfig(
+                default="model-router",
+                providers={
+                    "model-router": LLMProviderConfig(
+                        model="glm-5.2",
+                        author="z-ai",
+                        base_url="https://openrouter.ai/api/v1",
+                        api_key="test-key",
+                        context_window=1_048_576,
+                        max_tokens=384_000,
+                    )
+                },
+            )
+        )
+
+        rt = Runtime.from_config_store(_make_store(config))
+
+        assert isinstance(rt.agent.llm_provider, OpenAICompatibleProvider)
+        assert rt.agent.llm_provider.name == "model-router"
+        assert rt.agent.llm_provider.author == "z-ai"
+        assert rt.agent.llm_provider.max_tokens == 384_000
+        assert rt.agent.provider_config.context_window == 1_048_576
 
 
 class TestRuntimeMultiAgentEnabled:

--- a/tests/test_turn_intent.py
+++ b/tests/test_turn_intent.py
@@ -7,6 +7,7 @@ from dojoagents.agent.harnesses.portfolio import PortfolioTaskHarness
 from dojoagents.agent.models import ChatRequest, LLMResult, ToolCall, ToolResult
 from dojoagents.agent.providers import StaticLLMProvider
 from dojoagents.agent.turn_intent import (
+    DEFAULT_TURN_INTENT,
     TurnIntentResult,
     build_turn_intent_anchor,
     build_turn_intent_anchor_async,
@@ -113,6 +114,21 @@ async def test_build_turn_intent_anchor_async() -> None:
     assert "不要继续执行旧任务" in anchor
     assert "execute_code 本轮不可用" not in anchor
     assert "execute_code unavailable" not in anchor
+
+
+@pytest.mark.asyncio
+async def test_build_turn_intent_anchor_skips_classifier_without_history() -> None:
+    provider = StaticLLMProvider([LLMResult(content="main response")])
+
+    anchor, intent = await build_turn_intent_anchor_async(
+        _request("Analyze this request"),
+        provider,
+        model="test-model",
+    )
+
+    assert anchor == ""
+    assert intent == DEFAULT_TURN_INTENT
+    assert provider.calls == []
 
 
 def test_portfolio_harness_does_not_match_folio_tab_alone() -> None:


### PR DESCRIPTION
## Summary

This pull request improves DojoAgents documentation, provider configuration,
generated-memory management, and runtime reliability.

## Changes

- Add bilingual agent internals documentation covering the runtime, agent loop,
  tools, events, memory, plugins, and multi-agent planning.
- Add bilingual known-limitations documentation with explicit behavioral
  boundaries and validation status.
- Extend OpenAI-compatible provider configuration with token and context-window
  settings, including dashboard configuration support.
- Add a dashboard API for deleting generated memory with path validation and
  post-deletion verification.
- Improve portfolio migration compatibility and market-data fallback behavior.
- Honor both provider and request token limits for MCP sampling.
- Avoid unnecessary turn-intent classification when no conversation history is
  available.
- Update affected tests and stale fixtures to match current runtime contracts.

## Validation

- 141 targeted regression tests passed.
- Ruff checks passed.
- MkDocs strict build passed.
- Dashboard frontend build passed.

The full test suite was not reported as completed because the single-process run
encountered prolonged filesystem I/O stalls.

## Known dependency issue

`npm audit` currently reports one high-severity issue in the transitive
`postcss@8.5.15` dependency. This pull request does not modify the dependency
lockfile and records the issue as a known limitation.